### PR TITLE
Add GPU mask-based disable rendering with CPU fallback

### DIFF
--- a/common/src/main/java/com/xtracr/realcamera/RealCameraCore.java
+++ b/common/src/main/java/com/xtracr/realcamera/RealCameraCore.java
@@ -8,6 +8,8 @@ import com.xtracr.realcamera.compat.DisableHelper;
 import com.xtracr.realcamera.config.BindTarget;
 import com.xtracr.realcamera.config.BindTarget.DisableConfig;
 import com.xtracr.realcamera.config.ConfigFile;
+import com.xtracr.realcamera.render.RealCameraRenderTypes;
+import com.xtracr.realcamera.render.RealCameraShaders;
 import com.xtracr.realcamera.util.*;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -129,6 +131,13 @@ public class RealCameraCore {
             DisableConfig[] disableConfigs = currentTarget().filteredDisableConfigs(config -> builtBuffer.textureId().contains(config.textureId()));
             for (DisableConfig config : disableConfigs) {
                 if (config.disableAll()) return;
+            }
+            RealCameraRenderTypes.MaskedRenderType masked = RealCameraRenderTypes.getMaskedRenderType(builtBuffer.renderType(), builtBuffer.textureId(), disableConfigs);
+            if (masked != null) {
+                RealCameraShaders.setDisableDepth(masked.shader(), depth);
+                VertexConsumer buffer = bufferSource.getBuffer(masked.renderType());
+                for (VertexData vertex : builtBuffer.vertexBuffer()) vertex.render(buffer);
+                return;
             }
             VertexConsumer buffer = bufferSource.getBuffer(builtBuffer.renderType());
             if (!builtBuffer.renderType().canConsolidateConsecutiveGeometry()) {

--- a/common/src/main/java/com/xtracr/realcamera/render/DisableMaskCache.java
+++ b/common/src/main/java/com/xtracr/realcamera/render/DisableMaskCache.java
@@ -1,0 +1,104 @@
+package com.xtracr.realcamera.render;
+
+import com.mojang.blaze3d.platform.NativeImage;
+import com.xtracr.realcamera.RealCamera;
+import com.xtracr.realcamera.config.BindTarget.DisableConfig;
+import com.xtracr.realcamera.config.BindTarget.UVRectangle;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.texture.DynamicTexture;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public final class DisableMaskCache {
+    private static final int MASK_SIZE = 2048;
+    private static final int MASK_COLOR = 0xFFFFFFFF;
+    private static final Map<CacheKey, ResourceLocation> CACHE = new HashMap<>();
+    private static ResourceLocation defaultMask;
+
+    private DisableMaskCache() {
+    }
+
+    public static ResourceLocation getMask(String textureId, DisableConfig[] configs) {
+        if (configs.length == 0) return getDefaultMask();
+        CacheKey key = new CacheKey(textureId, hashConfigs(configs));
+        ResourceLocation cached = CACHE.get(key);
+        if (cached != null) return cached;
+        ResourceLocation location = ResourceLocation.fromNamespaceAndPath(RealCamera.MODID, "mask/" + Integer.toHexString(key.hashCode()));
+        DynamicTexture texture = new DynamicTexture(buildMask(configs));
+        Minecraft.getInstance().getTextureManager().register(location, texture);
+        CACHE.put(key, location);
+        return location;
+    }
+
+    private static ResourceLocation getDefaultMask() {
+        if (defaultMask != null) return defaultMask;
+        defaultMask = ResourceLocation.fromNamespaceAndPath(RealCamera.MODID, "mask/default");
+        DynamicTexture texture = new DynamicTexture(new NativeImage(1, 1, false));
+        Minecraft.getInstance().getTextureManager().register(defaultMask, texture);
+        return defaultMask;
+    }
+
+    private static NativeImage buildMask(DisableConfig[] configs) {
+        NativeImage image = new NativeImage(MASK_SIZE, MASK_SIZE, false);
+        for (DisableConfig config : configs) {
+            for (UVRectangle rect : config.rectangles()) {
+                fillRect(image, rect);
+            }
+        }
+        return image;
+    }
+
+    private static void fillRect(NativeImage image, UVRectangle rect) {
+        float uMin = clamp01(Math.min(rect.uMin(), rect.uMax()));
+        float uMax = clamp01(Math.max(rect.uMin(), rect.uMax()));
+        float vMin = clamp01(Math.min(rect.vMin(), rect.vMax()));
+        float vMax = clamp01(Math.max(rect.vMin(), rect.vMax()));
+        int x0 = clamp((int) Math.floor(uMin * (MASK_SIZE - 1)), 0, MASK_SIZE - 1);
+        int x1 = clamp((int) Math.ceil(uMax * (MASK_SIZE - 1)), 0, MASK_SIZE - 1);
+        int y0 = clamp((int) Math.floor(vMin * (MASK_SIZE - 1)), 0, MASK_SIZE - 1);
+        int y1 = clamp((int) Math.ceil(vMax * (MASK_SIZE - 1)), 0, MASK_SIZE - 1);
+        for (int y = y0; y <= y1; y++) {
+            for (int x = x0; x <= x1; x++) {
+                image.setPixelRGBA(x, y, MASK_COLOR);
+            }
+        }
+    }
+
+    private static int hashConfigs(DisableConfig[] configs) {
+        int result = 1;
+        for (DisableConfig config : configs) {
+            result = 31 * result + hashConfig(config);
+        }
+        return result;
+    }
+
+    private static int hashConfig(DisableConfig config) {
+        int result = Objects.hash(config.name(), config.textureId(), config.disableAll());
+        for (UVRectangle rect : config.rectangles()) {
+            result = 31 * result + hashRect(rect);
+        }
+        return result;
+    }
+
+    private static int hashRect(UVRectangle rect) {
+        int result = Float.hashCode(rect.uMin());
+        result = 31 * result + Float.hashCode(rect.vMin());
+        result = 31 * result + Float.hashCode(rect.uMax());
+        result = 31 * result + Float.hashCode(rect.vMax());
+        return result;
+    }
+
+    private static int clamp(int value, int min, int max) {
+        return Math.max(min, Math.min(max, value));
+    }
+
+    private static float clamp01(float value) {
+        return Math.max(0.0f, Math.min(1.0f, value));
+    }
+
+    private record CacheKey(String textureId, int configHash) {
+    }
+}

--- a/common/src/main/java/com/xtracr/realcamera/render/RealCameraRenderTypes.java
+++ b/common/src/main/java/com/xtracr/realcamera/render/RealCameraRenderTypes.java
@@ -1,0 +1,171 @@
+package com.xtracr.realcamera.render;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.mojang.blaze3d.vertex.VertexFormat;
+import com.xtracr.realcamera.RealCamera;
+import com.xtracr.realcamera.config.BindTarget.DisableConfig;
+import net.minecraft.client.renderer.RenderStateShard;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.ShaderInstance;
+import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class RealCameraRenderTypes extends RenderType {
+    private static final int BUFFER_SIZE = 1536;
+    private static final int MASK_TEXTURE_UNIT = 3;
+    private static final ShaderStateShard ENTITY_SOLID_SHADER = new ShaderStateShard(RealCameraShaders::entitySolid);
+    private static final ShaderStateShard ENTITY_CUTOUT_SHADER = new ShaderStateShard(RealCameraShaders::entityCutout);
+    private static final ShaderStateShard ENTITY_TRANSLUCENT_SHADER = new ShaderStateShard(RealCameraShaders::entityTranslucent);
+    private static final Map<RenderKey, RenderType> CACHE = new HashMap<>();
+    private static final Method CREATE_METHOD = findCreateMethod();
+
+    private RealCameraRenderTypes() {
+        super("realcamera_dummy", DefaultVertexFormat.NEW_ENTITY, VertexFormat.Mode.QUADS, 0, false, false, () -> {}, () -> {});
+    }
+
+    public static @Nullable MaskedRenderType getMaskedRenderType(RenderType base, String textureId, DisableConfig[] disableConfigs) {
+        if (CREATE_METHOD == null) return null;
+        ResourceLocation texture = ResourceLocation.tryParse(textureId);
+        if (texture == null) return null;
+        RenderTypeKind kind = classify(base, texture);
+        if (kind == null) return null;
+        ShaderInstance shader = shaderFor(kind);
+        if (shader == null) return null;
+        ResourceLocation mask = DisableMaskCache.getMask(textureId, disableConfigs);
+        boolean affectsOutline = base.outline().isPresent();
+        RenderKey key = new RenderKey(kind, texture, mask, affectsOutline);
+        RenderType masked = CACHE.get(key);
+        if (masked == null) {
+            masked = buildRenderType(key.kind(), key.texture(), key.mask(), key.affectsOutline());
+            if (masked == null) return null;
+            CACHE.put(key, masked);
+        }
+        return new MaskedRenderType(masked, shader);
+    }
+
+    private static RenderTypeKind classify(RenderType base, ResourceLocation texture) {
+        if (base == RenderType.entitySolid(texture)) return RenderTypeKind.ENTITY_SOLID;
+        if (base == RenderType.entityCutout(texture)) return RenderTypeKind.ENTITY_CUTOUT;
+        if (base == RenderType.entityCutoutNoCull(texture) || base == RenderType.entityCutoutNoCull(texture, false)) {
+            return RenderTypeKind.ENTITY_CUTOUT_NO_CULL;
+        }
+        if (base == RenderType.entityCutoutNoCullZOffset(texture) || base == RenderType.entityCutoutNoCullZOffset(texture, false)) {
+            return RenderTypeKind.ENTITY_CUTOUT_NO_CULL_Z_OFFSET;
+        }
+        if (base == RenderType.entityTranslucent(texture) || base == RenderType.entityTranslucent(texture, false)) {
+            return RenderTypeKind.ENTITY_TRANSLUCENT;
+        }
+        if (base == RenderType.entityTranslucentCull(texture)) return RenderTypeKind.ENTITY_TRANSLUCENT_CULL;
+        return null;
+    }
+
+    private static ShaderInstance shaderFor(RenderTypeKind kind) {
+        return switch (kind) {
+            case ENTITY_SOLID -> RealCameraShaders.entitySolid();
+            case ENTITY_CUTOUT, ENTITY_CUTOUT_NO_CULL, ENTITY_CUTOUT_NO_CULL_Z_OFFSET -> RealCameraShaders.entityCutout();
+            case ENTITY_TRANSLUCENT, ENTITY_TRANSLUCENT_CULL -> RealCameraShaders.entityTranslucent();
+        };
+    }
+
+    private static ShaderStateShard shaderStateFor(RenderTypeKind kind) {
+        return switch (kind) {
+            case ENTITY_SOLID -> ENTITY_SOLID_SHADER;
+            case ENTITY_CUTOUT, ENTITY_CUTOUT_NO_CULL, ENTITY_CUTOUT_NO_CULL_Z_OFFSET -> ENTITY_CUTOUT_SHADER;
+            case ENTITY_TRANSLUCENT, ENTITY_TRANSLUCENT_CULL -> ENTITY_TRANSLUCENT_SHADER;
+        };
+    }
+
+    private static RenderType buildRenderType(RenderTypeKind kind, ResourceLocation texture, ResourceLocation mask, boolean affectsOutline) {
+        CompositeState.CompositeStateBuilder builder = CompositeState.builder()
+                .setShaderState(shaderStateFor(kind))
+                .setTextureState(new TextureStateShard(texture, false, false))
+                .setTexturingState(maskTexturingState(mask));
+        switch (kind) {
+            case ENTITY_SOLID, ENTITY_CUTOUT -> builder
+                    .setTransparencyState(NO_TRANSPARENCY)
+                    .setLightmapState(LIGHTMAP)
+                    .setOverlayState(OVERLAY);
+            case ENTITY_CUTOUT_NO_CULL -> builder
+                    .setTransparencyState(NO_TRANSPARENCY)
+                    .setCullState(NO_CULL)
+                    .setLightmapState(LIGHTMAP)
+                    .setOverlayState(OVERLAY);
+            case ENTITY_CUTOUT_NO_CULL_Z_OFFSET -> builder
+                    .setTransparencyState(NO_TRANSPARENCY)
+                    .setCullState(NO_CULL)
+                    .setLayeringState(VIEW_OFFSET_Z_LAYERING)
+                    .setLightmapState(LIGHTMAP)
+                    .setOverlayState(OVERLAY);
+            case ENTITY_TRANSLUCENT -> builder
+                    .setTransparencyState(TRANSLUCENT_TRANSPARENCY)
+                    .setCullState(NO_CULL)
+                    .setLightmapState(LIGHTMAP)
+                    .setOverlayState(OVERLAY);
+            case ENTITY_TRANSLUCENT_CULL -> builder
+                    .setTransparencyState(TRANSLUCENT_TRANSPARENCY)
+                    .setCullState(CULL)
+                    .setLightmapState(LIGHTMAP)
+                    .setOverlayState(OVERLAY);
+        }
+        CompositeState state = builder.createCompositeState(affectsOutline);
+        try {
+            return (RenderType) CREATE_METHOD.invoke(null, renderTypeName(kind), DefaultVertexFormat.NEW_ENTITY, VertexFormat.Mode.QUADS, BUFFER_SIZE, true, sortOnUpload(kind), state);
+        } catch (ReflectiveOperationException e) {
+            RealCamera.LOGGER.error("Failed to create render type for mask shader", e);
+            return null;
+        }
+    }
+
+    private static boolean sortOnUpload(RenderTypeKind kind) {
+        return kind == RenderTypeKind.ENTITY_TRANSLUCENT || kind == RenderTypeKind.ENTITY_TRANSLUCENT_CULL;
+    }
+
+    private static TexturingStateShard maskTexturingState(ResourceLocation mask) {
+        return new TexturingStateShard("realcamera_mask", () -> {
+            DEFAULT_TEXTURING.setupRenderState();
+            RenderSystem.setShaderTexture(MASK_TEXTURE_UNIT, mask);
+        }, DEFAULT_TEXTURING::clearRenderState);
+    }
+
+    private static String renderTypeName(RenderTypeKind kind) {
+        return switch (kind) {
+            case ENTITY_SOLID -> "realcamera_entity_solid";
+            case ENTITY_CUTOUT -> "realcamera_entity_cutout";
+            case ENTITY_CUTOUT_NO_CULL -> "realcamera_entity_cutout_no_cull";
+            case ENTITY_CUTOUT_NO_CULL_Z_OFFSET -> "realcamera_entity_cutout_no_cull_z_offset";
+            case ENTITY_TRANSLUCENT -> "realcamera_entity_translucent";
+            case ENTITY_TRANSLUCENT_CULL -> "realcamera_entity_translucent_cull";
+        };
+    }
+
+    private static @Nullable Method findCreateMethod() {
+        try {
+            Method method = RenderType.class.getDeclaredMethod("create", String.class, VertexFormat.class, VertexFormat.Mode.class, int.class, boolean.class, boolean.class, CompositeState.class);
+            method.setAccessible(true);
+            return method;
+        } catch (NoSuchMethodException e) {
+            RealCamera.LOGGER.error("RenderType.create method not found; GPU masking is disabled", e);
+            return null;
+        }
+    }
+
+    public record MaskedRenderType(RenderType renderType, ShaderInstance shader) {
+    }
+
+    private enum RenderTypeKind {
+        ENTITY_SOLID,
+        ENTITY_CUTOUT,
+        ENTITY_CUTOUT_NO_CULL,
+        ENTITY_CUTOUT_NO_CULL_Z_OFFSET,
+        ENTITY_TRANSLUCENT,
+        ENTITY_TRANSLUCENT_CULL
+    }
+
+    private record RenderKey(RenderTypeKind kind, ResourceLocation texture, ResourceLocation mask, boolean affectsOutline) {
+    }
+}

--- a/common/src/main/java/com/xtracr/realcamera/render/RealCameraShaders.java
+++ b/common/src/main/java/com/xtracr/realcamera/render/RealCameraShaders.java
@@ -1,0 +1,42 @@
+package com.xtracr.realcamera.render;
+
+import net.minecraft.client.renderer.ShaderInstance;
+
+public final class RealCameraShaders {
+    private static ShaderInstance entitySolidShader;
+    private static ShaderInstance entityCutoutShader;
+    private static ShaderInstance entityTranslucentShader;
+
+    private RealCameraShaders() {
+    }
+
+    public static ShaderInstance entitySolid() {
+        return entitySolidShader;
+    }
+
+    public static ShaderInstance entityCutout() {
+        return entityCutoutShader;
+    }
+
+    public static ShaderInstance entityTranslucent() {
+        return entityTranslucentShader;
+    }
+
+    public static void setEntitySolid(ShaderInstance shader) {
+        entitySolidShader = shader;
+    }
+
+    public static void setEntityCutout(ShaderInstance shader) {
+        entityCutoutShader = shader;
+    }
+
+    public static void setEntityTranslucent(ShaderInstance shader) {
+        entityTranslucentShader = shader;
+    }
+
+    public static void setDisableDepth(ShaderInstance shader, float depth) {
+        if (shader == null) return;
+        shader.safeGetUniform("DisableDepth").set(depth);
+        shader.markDirty();
+    }
+}

--- a/common/src/main/resources/assets/realcamera/shaders/core/realcamera_entity_cutout.fsh
+++ b/common/src/main/resources/assets/realcamera/shaders/core/realcamera_entity_cutout.fsh
@@ -1,0 +1,38 @@
+#version 150
+
+#moj_import <fog.glsl>
+
+uniform sampler2D Sampler0;
+uniform sampler2D Sampler3;
+
+uniform float DisableDepth;
+uniform vec4 ColorModulator;
+uniform float FogStart;
+uniform float FogEnd;
+uniform vec4 FogColor;
+
+in float vertexDistance;
+in vec4 vertexColor;
+in vec4 lightMapColor;
+in vec4 overlayColor;
+in vec2 texCoord0;
+in float viewZ;
+
+out vec4 fragColor;
+
+void main() {
+    if (viewZ > -DisableDepth) {
+        discard;
+    }
+    if (texture(Sampler3, texCoord0).r > 0.5) {
+        discard;
+    }
+    vec4 color = texture(Sampler0, texCoord0);
+    if (color.a < 0.1) {
+        discard;
+    }
+    color *= vertexColor * ColorModulator;
+    color.rgb = mix(overlayColor.rgb, color.rgb, overlayColor.a);
+    color *= lightMapColor;
+    fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
+}

--- a/common/src/main/resources/assets/realcamera/shaders/core/realcamera_entity_cutout.json
+++ b/common/src/main/resources/assets/realcamera/shaders/core/realcamera_entity_cutout.json
@@ -1,0 +1,22 @@
+{
+    "vertex": "realcamera_entity_cutout",
+    "fragment": "realcamera_entity_cutout",
+    "samplers": [
+        { "name": "Sampler0" },
+        { "name": "Sampler1" },
+        { "name": "Sampler2" },
+        { "name": "Sampler3" }
+    ],
+    "uniforms": [
+        { "name": "ModelViewMat", "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+        { "name": "ProjMat", "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+        { "name": "ColorModulator", "type": "float", "count": 4, "values": [ 1.0, 1.0, 1.0, 1.0 ] },
+        { "name": "Light0_Direction", "type": "float", "count": 3, "values": [ 0.0, 0.0, 0.0 ] },
+        { "name": "Light1_Direction", "type": "float", "count": 3, "values": [ 0.0, 0.0, 0.0 ] },
+        { "name": "FogStart", "type": "float", "count": 1, "values": [ 0.0 ] },
+        { "name": "FogEnd", "type": "float", "count": 1, "values": [ 1.0 ] },
+        { "name": "FogColor", "type": "float", "count": 4, "values": [ 0.0, 0.0, 0.0, 0.0 ] },
+        { "name": "FogShape", "type": "int", "count": 1, "values": [ 0 ] },
+        { "name": "DisableDepth", "type": "float", "count": 1, "values": [ 0.0 ] }
+    ]
+}

--- a/common/src/main/resources/assets/realcamera/shaders/core/realcamera_entity_cutout.vsh
+++ b/common/src/main/resources/assets/realcamera/shaders/core/realcamera_entity_cutout.vsh
@@ -1,0 +1,40 @@
+#version 150
+
+#moj_import <light.glsl>
+#moj_import <fog.glsl>
+
+in vec3 Position;
+in vec4 Color;
+in vec2 UV0;
+in ivec2 UV1;
+in ivec2 UV2;
+in vec3 Normal;
+
+uniform sampler2D Sampler1;
+uniform sampler2D Sampler2;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+uniform int FogShape;
+
+uniform vec3 Light0_Direction;
+uniform vec3 Light1_Direction;
+
+out float vertexDistance;
+out vec4 vertexColor;
+out vec4 lightMapColor;
+out vec4 overlayColor;
+out vec2 texCoord0;
+out float viewZ;
+
+void main() {
+    vec4 viewPos = ModelViewMat * vec4(Position, 1.0);
+    gl_Position = ProjMat * viewPos;
+
+    vertexDistance = fog_distance(Position, FogShape);
+    vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color);
+    lightMapColor = texelFetch(Sampler2, UV2 / 16, 0);
+    overlayColor = texelFetch(Sampler1, UV1, 0);
+    texCoord0 = UV0;
+    viewZ = viewPos.z;
+}

--- a/common/src/main/resources/assets/realcamera/shaders/core/realcamera_entity_solid.fsh
+++ b/common/src/main/resources/assets/realcamera/shaders/core/realcamera_entity_solid.fsh
@@ -1,0 +1,34 @@
+#version 150
+
+#moj_import <fog.glsl>
+
+uniform sampler2D Sampler0;
+uniform sampler2D Sampler3;
+
+uniform float DisableDepth;
+uniform vec4 ColorModulator;
+uniform float FogStart;
+uniform float FogEnd;
+uniform vec4 FogColor;
+
+in float vertexDistance;
+in vec4 vertexColor;
+in vec4 lightMapColor;
+in vec4 overlayColor;
+in vec2 texCoord0;
+in float viewZ;
+
+out vec4 fragColor;
+
+void main() {
+    if (viewZ > -DisableDepth) {
+        discard;
+    }
+    if (texture(Sampler3, texCoord0).r > 0.5) {
+        discard;
+    }
+    vec4 color = texture(Sampler0, texCoord0) * vertexColor * ColorModulator;
+    color.rgb = mix(overlayColor.rgb, color.rgb, overlayColor.a);
+    color *= lightMapColor;
+    fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
+}

--- a/common/src/main/resources/assets/realcamera/shaders/core/realcamera_entity_solid.json
+++ b/common/src/main/resources/assets/realcamera/shaders/core/realcamera_entity_solid.json
@@ -1,0 +1,22 @@
+{
+    "vertex": "realcamera_entity_solid",
+    "fragment": "realcamera_entity_solid",
+    "samplers": [
+        { "name": "Sampler0" },
+        { "name": "Sampler1" },
+        { "name": "Sampler2" },
+        { "name": "Sampler3" }
+    ],
+    "uniforms": [
+        { "name": "ModelViewMat", "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+        { "name": "ProjMat", "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+        { "name": "ColorModulator", "type": "float", "count": 4, "values": [ 1.0, 1.0, 1.0, 1.0 ] },
+        { "name": "Light0_Direction", "type": "float", "count": 3, "values": [ 0.0, 0.0, 0.0 ] },
+        { "name": "Light1_Direction", "type": "float", "count": 3, "values": [ 0.0, 0.0, 0.0 ] },
+        { "name": "FogStart", "type": "float", "count": 1, "values": [ 0.0 ] },
+        { "name": "FogEnd", "type": "float", "count": 1, "values": [ 1.0 ] },
+        { "name": "FogColor", "type": "float", "count": 4, "values": [ 0.0, 0.0, 0.0, 0.0 ] },
+        { "name": "FogShape", "type": "int", "count": 1, "values": [ 0 ] },
+        { "name": "DisableDepth", "type": "float", "count": 1, "values": [ 0.0 ] }
+    ]
+}

--- a/common/src/main/resources/assets/realcamera/shaders/core/realcamera_entity_solid.vsh
+++ b/common/src/main/resources/assets/realcamera/shaders/core/realcamera_entity_solid.vsh
@@ -1,0 +1,40 @@
+#version 150
+
+#moj_import <light.glsl>
+#moj_import <fog.glsl>
+
+in vec3 Position;
+in vec4 Color;
+in vec2 UV0;
+in ivec2 UV1;
+in ivec2 UV2;
+in vec3 Normal;
+
+uniform sampler2D Sampler1;
+uniform sampler2D Sampler2;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+uniform int FogShape;
+
+uniform vec3 Light0_Direction;
+uniform vec3 Light1_Direction;
+
+out float vertexDistance;
+out vec4 vertexColor;
+out vec4 lightMapColor;
+out vec4 overlayColor;
+out vec2 texCoord0;
+out float viewZ;
+
+void main() {
+    vec4 viewPos = ModelViewMat * vec4(Position, 1.0);
+    gl_Position = ProjMat * viewPos;
+
+    vertexDistance = fog_distance(Position, FogShape);
+    vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color);
+    lightMapColor = texelFetch(Sampler2, UV2 / 16, 0);
+    overlayColor = texelFetch(Sampler1, UV1, 0);
+    texCoord0 = UV0;
+    viewZ = viewPos.z;
+}

--- a/common/src/main/resources/assets/realcamera/shaders/core/realcamera_entity_translucent.fsh
+++ b/common/src/main/resources/assets/realcamera/shaders/core/realcamera_entity_translucent.fsh
@@ -1,0 +1,38 @@
+#version 150
+
+#moj_import <fog.glsl>
+
+uniform sampler2D Sampler0;
+uniform sampler2D Sampler3;
+
+uniform float DisableDepth;
+uniform vec4 ColorModulator;
+uniform float FogStart;
+uniform float FogEnd;
+uniform vec4 FogColor;
+
+in float vertexDistance;
+in vec4 vertexColor;
+in vec4 lightMapColor;
+in vec4 overlayColor;
+in vec2 texCoord0;
+in float viewZ;
+
+out vec4 fragColor;
+
+void main() {
+    if (viewZ > -DisableDepth) {
+        discard;
+    }
+    if (texture(Sampler3, texCoord0).r > 0.5) {
+        discard;
+    }
+    vec4 color = texture(Sampler0, texCoord0);
+    if (color.a < 0.1) {
+        discard;
+    }
+    color *= vertexColor * ColorModulator;
+    color.rgb = mix(overlayColor.rgb, color.rgb, overlayColor.a);
+    color *= lightMapColor;
+    fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
+}

--- a/common/src/main/resources/assets/realcamera/shaders/core/realcamera_entity_translucent.json
+++ b/common/src/main/resources/assets/realcamera/shaders/core/realcamera_entity_translucent.json
@@ -1,0 +1,22 @@
+{
+    "vertex": "realcamera_entity_translucent",
+    "fragment": "realcamera_entity_translucent",
+    "samplers": [
+        { "name": "Sampler0" },
+        { "name": "Sampler1" },
+        { "name": "Sampler2" },
+        { "name": "Sampler3" }
+    ],
+    "uniforms": [
+        { "name": "ModelViewMat", "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+        { "name": "ProjMat", "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+        { "name": "ColorModulator", "type": "float", "count": 4, "values": [ 1.0, 1.0, 1.0, 1.0 ] },
+        { "name": "Light0_Direction", "type": "float", "count": 3, "values": [ 0.0, 0.0, 0.0 ] },
+        { "name": "Light1_Direction", "type": "float", "count": 3, "values": [ 0.0, 0.0, 0.0 ] },
+        { "name": "FogStart", "type": "float", "count": 1, "values": [ 0.0 ] },
+        { "name": "FogEnd", "type": "float", "count": 1, "values": [ 1.0 ] },
+        { "name": "FogColor", "type": "float", "count": 4, "values": [ 0.0, 0.0, 0.0, 0.0 ] },
+        { "name": "FogShape", "type": "int", "count": 1, "values": [ 0 ] },
+        { "name": "DisableDepth", "type": "float", "count": 1, "values": [ 0.0 ] }
+    ]
+}

--- a/common/src/main/resources/assets/realcamera/shaders/core/realcamera_entity_translucent.vsh
+++ b/common/src/main/resources/assets/realcamera/shaders/core/realcamera_entity_translucent.vsh
@@ -1,0 +1,40 @@
+#version 150
+
+#moj_import <light.glsl>
+#moj_import <fog.glsl>
+
+in vec3 Position;
+in vec4 Color;
+in vec2 UV0;
+in ivec2 UV1;
+in ivec2 UV2;
+in vec3 Normal;
+
+uniform sampler2D Sampler1;
+uniform sampler2D Sampler2;
+
+uniform mat4 ModelViewMat;
+uniform mat4 ProjMat;
+uniform int FogShape;
+
+uniform vec3 Light0_Direction;
+uniform vec3 Light1_Direction;
+
+out float vertexDistance;
+out vec4 vertexColor;
+out vec4 lightMapColor;
+out vec4 overlayColor;
+out vec2 texCoord0;
+out float viewZ;
+
+void main() {
+    vec4 viewPos = ModelViewMat * vec4(Position, 1.0);
+    gl_Position = ProjMat * viewPos;
+
+    vertexDistance = fog_distance(Position, FogShape);
+    vertexColor = minecraft_mix_light(Light0_Direction, Light1_Direction, Normal, Color);
+    lightMapColor = texelFetch(Sampler2, UV2 / 16, 0);
+    overlayColor = texelFetch(Sampler1, UV1, 0);
+    texCoord0 = UV0;
+    viewZ = viewPos.z;
+}

--- a/fabric/src/main/java/com/xtracr/realcamera/RealCameraFabric.java
+++ b/fabric/src/main/java/com/xtracr/realcamera/RealCameraFabric.java
@@ -5,13 +5,22 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
+import net.fabricmc.fabric.api.client.rendering.v1.CoreShaderRegistrationCallback;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
 import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.resources.ResourceLocation;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.xtracr.realcamera.render.RealCameraShaders;
 
 @Environment(EnvType.CLIENT)
 public class RealCameraFabric implements ClientModInitializer, RealCamera {
     @Override
     public void onInitializeClient() {
+        CoreShaderRegistrationCallback.EVENT.register(context -> {
+            context.register(ResourceLocation.fromNamespaceAndPath(RealCamera.MODID, "realcamera_entity_solid"), DefaultVertexFormat.NEW_ENTITY, RealCameraShaders::setEntitySolid);
+            context.register(ResourceLocation.fromNamespaceAndPath(RealCamera.MODID, "realcamera_entity_cutout"), DefaultVertexFormat.NEW_ENTITY, RealCameraShaders::setEntityCutout);
+            context.register(ResourceLocation.fromNamespaceAndPath(RealCamera.MODID, "realcamera_entity_translucent"), DefaultVertexFormat.NEW_ENTITY, RealCameraShaders::setEntityTranslucent);
+        });
         initialize();
         KeyMappings.register(KeyBindingHelper::registerKeyBinding);
 

--- a/neoforge/src/main/java/com/xtracr/realcamera/RealCameraNeoForge.java
+++ b/neoforge/src/main/java/com/xtracr/realcamera/RealCameraNeoForge.java
@@ -21,6 +21,7 @@ public class RealCameraNeoForge implements RealCamera {
         this.modContainer = modContainer;
         modEventBus.addListener(this::clientSetup);
         modEventBus.addListener(this::onKeyRegister);
+        modEventBus.addListener(RealCameraNeoForgeShaders::onRegisterShaders);
     }
 
     public void clientSetup(FMLClientSetupEvent event) {

--- a/neoforge/src/main/java/com/xtracr/realcamera/RealCameraNeoForgeShaders.java
+++ b/neoforge/src/main/java/com/xtracr/realcamera/RealCameraNeoForgeShaders.java
@@ -1,0 +1,23 @@
+package com.xtracr.realcamera;
+
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.xtracr.realcamera.render.RealCameraShaders;
+import net.minecraft.client.renderer.ShaderInstance;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.client.event.RegisterShadersEvent;
+import java.io.IOException;
+
+public final class RealCameraNeoForgeShaders {
+    private RealCameraNeoForgeShaders() {
+    }
+
+    public static void onRegisterShaders(RegisterShadersEvent event) {
+        try {
+            event.registerShader(new ShaderInstance(event.getResourceProvider(), ResourceLocation.fromNamespaceAndPath(RealCamera.MODID, "realcamera_entity_solid").toString(), DefaultVertexFormat.NEW_ENTITY), RealCameraShaders::setEntitySolid);
+            event.registerShader(new ShaderInstance(event.getResourceProvider(), ResourceLocation.fromNamespaceAndPath(RealCamera.MODID, "realcamera_entity_cutout").toString(), DefaultVertexFormat.NEW_ENTITY), RealCameraShaders::setEntityCutout);
+            event.registerShader(new ShaderInstance(event.getResourceProvider(), ResourceLocation.fromNamespaceAndPath(RealCamera.MODID, "realcamera_entity_translucent").toString(), DefaultVertexFormat.NEW_ENTITY), RealCameraShaders::setEntityTranslucent);
+        } catch (IOException e) {
+            RealCamera.LOGGER.error("Failed to register RealCamera shaders", e);
+        }
+    }
+}


### PR DESCRIPTION
- 新增遮罩纹理缓存与自定义实体着色器（solid/cutout/translucent），用 DisableDepth 与遮罩采样实现 GPU 端剔除                      
- 为标准实体 RenderType 构建带遮罩的 RenderType，并绑定遮罩到纹理单元 3（Sampler3）以避免采样冲突                                
- 渲染路径优先走 GPU，遇到非标准 RenderType 时自动回退现有 CPU 网格剔除逻辑                                                      
- Fabric/NeoForge 侧完成 shader 注册，移除对 accessor 的依赖