### PR TITLE
Backport 1.21.1 optimizations to 1.20.1

### DIFF
--- a/common/src/main/java/com/xtracr/realcamera/RealCameraCore.java
+++ b/common/src/main/java/com/xtracr/realcamera/RealCameraCore.java
@@ -109,7 +109,7 @@ public class RealCameraCore {
         eulerAngle = MathUtil.getEulerAngleYXZ(SmoothUtil.smoothRotation(lastResult.getRotation())).scale(Math.toDegrees(1));
     }
 
-    public static void renderCameraEntity(Minecraft client, float deltaTick, MultiBufferSource bufferSource) {
+    public static void renderCameraEntity(Minecraft client, float deltaTick, MultiBufferSource bufferSource, Matrix4f modelView) {
         Vec3 targetEulerAngle = MathUtil.getEulerAngleYXZ(lastResult.getRotation());
         Matrix4f invertedCameraPose = new Matrix4f()
                 .rotateZ((float) targetEulerAngle.z())
@@ -119,12 +119,15 @@ public class RealCameraCore {
                 .invert()
                 .translate(Vec3.ZERO.subtract(lastResult.getPosition()).toVector3f());
         PoseStack poseStack = new PoseStack();
-        poseStack.last().pose().mul(invertedCameraPose);
-        poseStack.last().normal().mul(new Matrix3f(invertedCameraPose));
+        Matrix4f inverseModelView = modelView.invert(new Matrix4f());
+        Matrix4f pose = new Matrix4f(invertedCameraPose).mulLocal(inverseModelView);
+        poseStack.last().pose().mul(pose);
+        poseStack.last().normal().mul(new Matrix3f(pose));
         Entity entity = client.getCameraEntity();
         EntityRenderDispatcher dispatcher = client.getEntityRenderDispatcher();
         MultiVertexCatcher catcher = MultiVertexCatcher.defaultImpl();
         dispatcher.render(entity, 0, 0, 0, Mth.lerp(deltaTick, entity.yRotO, entity.getYRot()), deltaTick, poseStack, catcher, dispatcher.getPackedLightCoords(entity, deltaTick));
+        final float m02 = modelView.m02(), m12 = modelView.m12(), m22 = modelView.m22(), m32 = modelView.m32();
         final float depth = currentTarget().disablingDepth();
         catcher.endCatching(builtBuffer -> {
             DisableConfig[] disableConfigs = currentTarget().filteredDisableConfigs(config -> builtBuffer.textureId().contains(config.textureId()));
@@ -139,9 +142,9 @@ public class RealCameraCore {
             builtBuffer.vertexBuffer().primitiveStream().forEach(primitive -> {
                 primitiveFor:
                 for (VertexData vertex : primitive) {
-                    if (vertex.z() > -depth) continue;
+                    if (Math.fma(m02, vertex.x(), Math.fma(m12, vertex.y(), Math.fma(m22, vertex.z(), m32))) > -depth) continue;
                     for (DisableConfig config : disableConfigs) {
-                        if (config.test(vertex)) continue primitiveFor;
+                        if (config.disable(vertex)) continue primitiveFor;
                     }
                     for (VertexData vertexData : primitive) vertexData.render(buffer);
                     break;

--- a/common/src/main/java/com/xtracr/realcamera/config/BindTarget.java
+++ b/common/src/main/java/com/xtracr/realcamera/config/BindTarget.java
@@ -1,9 +1,17 @@
 package com.xtracr.realcamera.config;
 
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.xtracr.realcamera.util.VertexData;
+import it.unimi.dsi.fastutil.floats.Float2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.floats.FloatOpenHashSet;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.util.Mth;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
@@ -200,7 +208,22 @@ public record BindTarget(
         }
     }
 
-    public record DisableConfig(String name, String textureId, boolean disableAll, UVRectangle[] rectangles) implements Predicate<VertexData> {
+    @JsonAdapter(DisableConfig.Adapter.class)
+    public static class DisableConfig {
+        private final Float2ObjectOpenHashMap<FloatOpenHashSet> disableCacheMap = new Float2ObjectOpenHashMap<>();
+        private final String name;
+        private final String textureId;
+        private final boolean disableAll;
+        private final UVRectangle[] rectangles;
+
+        public DisableConfig(String name, String textureId, boolean disableAll, UVRectangle[] rectangles) {
+            this.name = name;
+            this.textureId = textureId;
+            this.disableAll = disableAll;
+            this.rectangles = rectangles;
+            disableCacheMap.defaultReturnValue(new FloatOpenHashSet());
+        }
+
         public static DisableConfig read(FriendlyByteBuf byteBuf) {
             String name = byteBuf.readUtf();
             String textureId = byteBuf.readUtf();
@@ -210,6 +233,22 @@ public record BindTarget(
                 rectangles[i] = UVRectangle.read(byteBuf);
             }
             return new DisableConfig(name, textureId, disableAll, rectangles);
+        }
+
+        public String name() {
+            return name;
+        }
+
+        public String textureId() {
+            return textureId;
+        }
+
+        public boolean disableAll() {
+            return disableAll;
+        }
+
+        public UVRectangle[] rectangles() {
+            return rectangles;
         }
 
         public void write(FriendlyByteBuf byteBuf) {
@@ -222,13 +261,72 @@ public record BindTarget(
             }
         }
 
-        @Override
-        public boolean test(VertexData vertex) {
+        public boolean disable(VertexData vertex) {
             final float u = vertex.u(), v = vertex.v();
-            for (UVRectangle rect : rectangles) {
-                if (rect.contains(u, v)) return true;
+            final FloatOpenHashSet cachedVs = disableCacheMap.get(u);
+            if (!cachedVs.isEmpty()) {
+                if (cachedVs.contains(v)) return true;
+                if (cachedVs.contains(-v)) return false;
             }
+            for (UVRectangle rect : rectangles) {
+                if (!rect.contains(u, v)) continue;
+                disableCacheMap.computeIfAbsent(u, k -> new FloatOpenHashSet()).add(v);
+                return true;
+            }
+            disableCacheMap.computeIfAbsent(u, k -> new FloatOpenHashSet()).add(-v);
             return false;
+        }
+
+        public static class Adapter extends TypeAdapter<DisableConfig> {
+            @Override
+            public void write(JsonWriter out, DisableConfig value) throws IOException {
+                out.beginObject();
+                out.name("name").value(value.name());
+                out.name("textureId").value(value.textureId());
+                out.name("disableAll").value(value.disableAll());
+                out.name("rectangles");
+                out.beginArray();
+                for (UVRectangle rect : value.rectangles()) {
+                    out.beginObject();
+                    out.name("uMin").value(rect.uMin());
+                    out.name("vMin").value(rect.vMin());
+                    out.name("uMax").value(rect.uMax());
+                    out.name("vMax").value(rect.vMax());
+                    out.endObject();
+                }
+                out.endArray();
+                out.endObject();
+            }
+
+            @Override
+            public DisableConfig read(JsonReader in) throws IOException {
+                in.beginObject();
+                in.nextName();
+                String name = in.nextString();
+                in.nextName();
+                String textureId = in.nextString();
+                in.nextName();
+                boolean disableAll = in.nextBoolean();
+                in.nextName();
+                in.beginArray();
+                ArrayList<UVRectangle> rectangles = new ArrayList<>();
+                while (in.hasNext()) {
+                    in.beginObject();
+                    in.nextName();
+                    float uMin = (float) in.nextDouble();
+                    in.nextName();
+                    float vMin = (float) in.nextDouble();
+                    in.nextName();
+                    float uMax = (float) in.nextDouble();
+                    in.nextName();
+                    float vMax = (float) in.nextDouble();
+                    in.endObject();
+                    rectangles.add(new UVRectangle(uMin, vMin, uMax, vMax));
+                }
+                in.endArray();
+                in.endObject();
+                return new DisableConfig(name, textureId, disableAll, rectangles.toArray(UVRectangle[]::new));
+            }
         }
     }
 

--- a/common/src/main/java/com/xtracr/realcamera/config/ModConfig.java
+++ b/common/src/main/java/com/xtracr/realcamera/config/ModConfig.java
@@ -221,7 +221,7 @@ public class ModConfig {
         binding.clamp();
         int activeConfigIndex = binding.activeConfigIndex;
         List<BindTarget> matchedTargets = binding.targetList.stream().filter(target -> textureId.contains(target.textureId())).toList();
-        if (activeConfigIndex == 0 || matchedTargets.isEmpty()) return matchedTargets;
+        if (activeConfigIndex <= 0 || matchedTargets.isEmpty()) return matchedTargets;
         return List.of(matchedTargets.get(Mth.clamp(activeConfigIndex - 1, 0, matchedTargets.size() - 1)));
     }
 
@@ -311,6 +311,7 @@ public class ModConfig {
             }
             swimOutTick = Mth.clamp(swimOutTick, 0, 40);
             bindResultRetentionFrames = Math.max(bindResultRetentionFrames, 0);
+            activeConfigIndex = Math.max(activeConfigIndex, 0);
             displacementSmoothFactor = Mth.clamp(displacementSmoothFactor, 0.0, 1.0);
             rotationSmoothFactor = Mth.clamp(rotationSmoothFactor, 0.0, 1.0);
             if (disableMainFeatureItems == null) disableMainFeatureItems = List.of();

--- a/common/src/main/java/com/xtracr/realcamera/gui/ModelAnalyser.java
+++ b/common/src/main/java/com/xtracr/realcamera/gui/ModelAnalyser.java
@@ -98,7 +98,7 @@ public class ModelAnalyser {
                 primitiveFor:
                 for (VertexData vertex : primitive) {
                     for (DisableConfig config : disableConfigs) {
-                        if (config.test(vertex)) continue primitiveFor;
+                        if (config.disable(vertex)) continue primitiveFor;
                     }
                     primitives.add(primitive);
                     break;
@@ -141,7 +141,7 @@ public class ModelAnalyser {
                 if (!getPolygon(primitive).contains(mouseX, mouseY)) continue;
                 VertexData vertex = primitive[0];
                 float deltaZ = vertex.normalZ() == 0 ? 0 : (vertex.normalX() * (mouseX - vertex.x()) + vertex.normalY() * (mouseY - vertex.y())) / vertex.normalZ();
-                sortByZ.add(new Object[]{record, primitive, vertex.z() + deltaZ});
+                sortByZ.add(new Object[]{record, primitive, vertex.z() - deltaZ});
             }
         }
         if (sortByZ.isEmpty()) return;

--- a/common/src/main/java/com/xtracr/realcamera/mixin/MixinLevelRenderer.java
+++ b/common/src/main/java/com/xtracr/realcamera/mixin/MixinLevelRenderer.java
@@ -27,7 +27,10 @@ public abstract class MixinLevelRenderer {
     private void realcamera$renderCameraEntity(PoseStack poseStack, float deltaTick, long limitTime, boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer, LightTexture lightTexture, Matrix4f matrix4f, CallbackInfo ci) {
         if (!RealCameraCore.isRendering()) return;
         MultiBufferSource.BufferSource bufferSource = renderBuffers.bufferSource();
-        if (!ConfigFile.config().isClassic()) RealCameraCore.renderCameraEntity(minecraft, deltaTick, bufferSource);
+        if (!ConfigFile.config().isClassic()) {
+            Matrix4f modelView = new Matrix4f(poseStack.last().pose());
+            RealCameraCore.renderCameraEntity(minecraft, deltaTick, bufferSource, modelView);
+        }
         else {
             Vec3 cameraPos = camera.getPosition();
             renderEntity(camera.getEntity(), cameraPos.x(), cameraPos.y(), cameraPos.z(), deltaTick, poseStack, bufferSource);


### PR DESCRIPTION
## 已在 1.20.1 回移植并与 1.21.1/dev 行为对齐的核心改动

- `common/src/main/java/com/xtracr/realcamera/config/BindTarget.java`
  - 将 `DisableConfig` 调整为**带 UV 缓存**的类并添加 `@JsonAdapter`
  - 保持配置 JSON 结构兼容
  - 减少重复的矩形判定开销

- `common/src/main/java/com/xtracr/realcamera/RealCameraCore.java`
  - `renderCameraEntity` 增加 `modelView` 参数
  - 使用 `modelView` 空间做深度裁剪，使 roll/旋转时的禁用判断更准确
  - 禁用判定统一改为使用 `config.disable(...)`

- `common/src/main/java/com/xtracr/realcamera/mixin/MixinLevelRenderer.java`
  - 从 `PoseStack` 获取 `modelView` 并传入 `renderCameraEntity`
  - 确保渲染路径与 1.21.1/dev 对齐

- `common/src/main/java/com/xtracr/realcamera/gui/ModelAnalyser.java`
  - 修复 `deltaZ` 符号问题，选面排序更稳定
  - 禁用判定统一改为使用 `config.disable(...)`

- `common/src/main/java/com/xtracr/realcamera/config/ModConfig.java`
  - 为 `activeConfigIndex` 增加下界保护，避免负值导致选择异常


## 未同步（为保持 1.20.1 兼容，不引入）

- 平台/构建迁移（Java 21、NeoForge、Gradle/Loom 升级）
  - 涉及：`build.gradle`、`settings.gradle`、`gradle.properties`、`gradle/wrapper/*`、`.github/workflows/*`

- 新渲染管线 API（`MeshData`、`ByteBufferBuilder`、`VertexConsumer.addVertex`）
  - 涉及：`common/src/main/java/com/xtracr/realcamera/util/*`

- 交互距离与帧时间 API
  - 涉及：`common/src/main/java/com/xtracr/realcamera/mixin/MixinGameRenderer.java`
  - 1.20.1 继续使用 `getFrameTime()` 与 `gameMode.getPickRange()`，未引入 `DeltaTracker`/新的交互距离接口

- TACZ 兼容删除
  - 涉及：`common/src/main/java/com/xtracr/realcamera/compat/CompatibilityHelper.java`
