### PR TITLE
Backport 1.21.1 optimizations to 1.20.1

### DIFF
--- a/common/src/main/java/com/xtracr/realcamera/RealCameraCore.java
+++ b/common/src/main/java/com/xtracr/realcamera/RealCameraCore.java
@@ -109,7 +109,7 @@ public class RealCameraCore {
         eulerAngle = MathUtil.getEulerAngleYXZ(SmoothUtil.smoothRotation(lastResult.getRotation())).scale(Math.toDegrees(1));
     }
 
-    public static void renderCameraEntity(Minecraft client, float deltaTick, MultiBufferSource bufferSource, Matrix4f modelView) {
+    public static void renderCameraEntity(Minecraft client, float deltaTick, MultiBufferSource bufferSource) {
         Vec3 targetEulerAngle = MathUtil.getEulerAngleYXZ(lastResult.getRotation());
         Matrix4f invertedCameraPose = new Matrix4f()
                 .rotateZ((float) targetEulerAngle.z())
@@ -119,15 +119,12 @@ public class RealCameraCore {
                 .invert()
                 .translate(Vec3.ZERO.subtract(lastResult.getPosition()).toVector3f());
         PoseStack poseStack = new PoseStack();
-        Matrix4f inverseModelView = modelView.invert(new Matrix4f());
-        Matrix4f pose = new Matrix4f(invertedCameraPose).mulLocal(inverseModelView);
-        poseStack.last().pose().mul(pose);
-        poseStack.last().normal().mul(new Matrix3f(pose));
+        poseStack.last().pose().mul(invertedCameraPose);
+        poseStack.last().normal().mul(new Matrix3f(invertedCameraPose));
         Entity entity = client.getCameraEntity();
         EntityRenderDispatcher dispatcher = client.getEntityRenderDispatcher();
         MultiVertexCatcher catcher = MultiVertexCatcher.defaultImpl();
         dispatcher.render(entity, 0, 0, 0, Mth.lerp(deltaTick, entity.yRotO, entity.getYRot()), deltaTick, poseStack, catcher, dispatcher.getPackedLightCoords(entity, deltaTick));
-        final float m02 = modelView.m02(), m12 = modelView.m12(), m22 = modelView.m22(), m32 = modelView.m32();
         final float depth = currentTarget().disablingDepth();
         catcher.endCatching(builtBuffer -> {
             DisableConfig[] disableConfigs = currentTarget().filteredDisableConfigs(config -> builtBuffer.textureId().contains(config.textureId()));
@@ -142,7 +139,7 @@ public class RealCameraCore {
             builtBuffer.vertexBuffer().primitiveStream().forEach(primitive -> {
                 primitiveFor:
                 for (VertexData vertex : primitive) {
-                    if (Math.fma(m02, vertex.x(), Math.fma(m12, vertex.y(), Math.fma(m22, vertex.z(), m32))) > -depth) continue;
+                    if (vertex.z() > -depth) continue;
                     for (DisableConfig config : disableConfigs) {
                         if (config.disable(vertex)) continue primitiveFor;
                     }

--- a/common/src/main/java/com/xtracr/realcamera/RealCameraCore.java
+++ b/common/src/main/java/com/xtracr/realcamera/RealCameraCore.java
@@ -109,7 +109,7 @@ public class RealCameraCore {
         eulerAngle = MathUtil.getEulerAngleYXZ(SmoothUtil.smoothRotation(lastResult.getRotation())).scale(Math.toDegrees(1));
     }
 
-    public static void renderCameraEntity(Minecraft client, float deltaTick, MultiBufferSource bufferSource) {
+    public static void renderCameraEntity(Minecraft client, float deltaTick, MultiBufferSource bufferSource, Matrix4f modelView) {
         Vec3 targetEulerAngle = MathUtil.getEulerAngleYXZ(lastResult.getRotation());
         Matrix4f invertedCameraPose = new Matrix4f()
                 .rotateZ((float) targetEulerAngle.z())
@@ -119,12 +119,15 @@ public class RealCameraCore {
                 .invert()
                 .translate(Vec3.ZERO.subtract(lastResult.getPosition()).toVector3f());
         PoseStack poseStack = new PoseStack();
-        poseStack.last().pose().mul(invertedCameraPose);
-        poseStack.last().normal().mul(new Matrix3f(invertedCameraPose));
+        Matrix4f inverseModelView = modelView.invert(new Matrix4f());
+        Matrix4f pose = new Matrix4f(invertedCameraPose).mulLocal(inverseModelView);
+        poseStack.last().pose().mul(pose);
+        poseStack.last().normal().mul(new Matrix3f(pose));
         Entity entity = client.getCameraEntity();
         EntityRenderDispatcher dispatcher = client.getEntityRenderDispatcher();
         MultiVertexCatcher catcher = MultiVertexCatcher.defaultImpl();
         dispatcher.render(entity, 0, 0, 0, Mth.lerp(deltaTick, entity.yRotO, entity.getYRot()), deltaTick, poseStack, catcher, dispatcher.getPackedLightCoords(entity, deltaTick));
+        final float m02 = modelView.m02(), m12 = modelView.m12(), m22 = modelView.m22(), m32 = modelView.m32();
         final float depth = currentTarget().disablingDepth();
         catcher.endCatching(builtBuffer -> {
             DisableConfig[] disableConfigs = currentTarget().filteredDisableConfigs(config -> builtBuffer.textureId().contains(config.textureId()));
@@ -139,9 +142,9 @@ public class RealCameraCore {
             builtBuffer.vertexBuffer().primitiveStream().forEach(primitive -> {
                 primitiveFor:
                 for (VertexData vertex : primitive) {
-                    if (vertex.z() > -depth) continue;
+                    if (Math.fma(m02, vertex.x(), Math.fma(m12, vertex.y(), Math.fma(m22, vertex.z(), m32))) > -depth) continue;
                     for (DisableConfig config : disableConfigs) {
-                        if (config.test(vertex)) continue primitiveFor;
+                        if (config.disable(vertex)) continue primitiveFor;
                     }
                     for (VertexData vertexData : primitive) vertexData.render(buffer);
                     break;

--- a/common/src/main/java/com/xtracr/realcamera/config/BindTarget.java
+++ b/common/src/main/java/com/xtracr/realcamera/config/BindTarget.java
@@ -1,9 +1,17 @@
 package com.xtracr.realcamera.config;
 
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.xtracr.realcamera.util.VertexData;
+import it.unimi.dsi.fastutil.floats.Float2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.floats.FloatOpenHashSet;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.util.Mth;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
@@ -200,7 +208,22 @@ public record BindTarget(
         }
     }
 
-    public record DisableConfig(String name, String textureId, boolean disableAll, UVRectangle[] rectangles) implements Predicate<VertexData> {
+    @JsonAdapter(DisableConfig.Adapter.class)
+    public static class DisableConfig {
+        private final Float2ObjectOpenHashMap<FloatOpenHashSet> disableCacheMap = new Float2ObjectOpenHashMap<>();
+        private final String name;
+        private final String textureId;
+        private final boolean disableAll;
+        private final UVRectangle[] rectangles;
+
+        public DisableConfig(String name, String textureId, boolean disableAll, UVRectangle[] rectangles) {
+            this.name = name;
+            this.textureId = textureId;
+            this.disableAll = disableAll;
+            this.rectangles = rectangles;
+            disableCacheMap.defaultReturnValue(new FloatOpenHashSet());
+        }
+
         public static DisableConfig read(FriendlyByteBuf byteBuf) {
             String name = byteBuf.readUtf();
             String textureId = byteBuf.readUtf();
@@ -210,6 +233,22 @@ public record BindTarget(
                 rectangles[i] = UVRectangle.read(byteBuf);
             }
             return new DisableConfig(name, textureId, disableAll, rectangles);
+        }
+
+        public String name() {
+            return name;
+        }
+
+        public String textureId() {
+            return textureId;
+        }
+
+        public boolean disableAll() {
+            return disableAll;
+        }
+
+        public UVRectangle[] rectangles() {
+            return rectangles;
         }
 
         public void write(FriendlyByteBuf byteBuf) {
@@ -222,13 +261,72 @@ public record BindTarget(
             }
         }
 
-        @Override
-        public boolean test(VertexData vertex) {
+        public boolean disable(VertexData vertex) {
             final float u = vertex.u(), v = vertex.v();
-            for (UVRectangle rect : rectangles) {
-                if (rect.contains(u, v)) return true;
+            final FloatOpenHashSet cachedVs = disableCacheMap.get(u);
+            if (!cachedVs.isEmpty()) {
+                if (cachedVs.contains(v)) return true;
+                if (cachedVs.contains(-v)) return false;
             }
+            for (UVRectangle rect : rectangles) {
+                if (!rect.contains(u, v)) continue;
+                disableCacheMap.computeIfAbsent(u, k -> new FloatOpenHashSet()).add(v);
+                return true;
+            }
+            disableCacheMap.computeIfAbsent(u, k -> new FloatOpenHashSet()).add(-v);
             return false;
+        }
+
+        public static class Adapter extends TypeAdapter<DisableConfig> {
+            @Override
+            public void write(JsonWriter out, DisableConfig value) throws IOException {
+                out.beginObject();
+                out.name("name").value(value.name());
+                out.name("textureId").value(value.textureId());
+                out.name("disableAll").value(value.disableAll());
+                out.name("rectangles");
+                out.beginArray();
+                for (UVRectangle rect : value.rectangles()) {
+                    out.beginObject();
+                    out.name("uMin").value(rect.uMin());
+                    out.name("vMin").value(rect.vMin());
+                    out.name("uMax").value(rect.uMax());
+                    out.name("vMax").value(rect.vMax());
+                    out.endObject();
+                }
+                out.endArray();
+                out.endObject();
+            }
+
+            @Override
+            public DisableConfig read(JsonReader in) throws IOException {
+                in.beginObject();
+                in.nextName();
+                String name = in.nextString();
+                in.nextName();
+                String textureId = in.nextString();
+                in.nextName();
+                boolean disableAll = in.nextBoolean();
+                in.nextName();
+                in.beginArray();
+                ArrayList<UVRectangle> rectangles = new ArrayList<>();
+                while (in.hasNext()) {
+                    in.beginObject();
+                    in.nextName();
+                    float uMin = (float) in.nextDouble();
+                    in.nextName();
+                    float vMin = (float) in.nextDouble();
+                    in.nextName();
+                    float uMax = (float) in.nextDouble();
+                    in.nextName();
+                    float vMax = (float) in.nextDouble();
+                    in.endObject();
+                    rectangles.add(new UVRectangle(uMin, vMin, uMax, vMax));
+                }
+                in.endArray();
+                in.endObject();
+                return new DisableConfig(name, textureId, disableAll, rectangles.toArray(UVRectangle[]::new));
+            }
         }
     }
 

--- a/common/src/main/java/com/xtracr/realcamera/config/ModConfig.java
+++ b/common/src/main/java/com/xtracr/realcamera/config/ModConfig.java
@@ -221,7 +221,7 @@ public class ModConfig {
         binding.clamp();
         int activeConfigIndex = binding.activeConfigIndex;
         List<BindTarget> matchedTargets = binding.targetList.stream().filter(target -> textureId.contains(target.textureId())).toList();
-        if (activeConfigIndex == 0 || matchedTargets.isEmpty()) return matchedTargets;
+        if (activeConfigIndex <= 0 || matchedTargets.isEmpty()) return matchedTargets;
         return List.of(matchedTargets.get(Mth.clamp(activeConfigIndex - 1, 0, matchedTargets.size() - 1)));
     }
 
@@ -311,6 +311,7 @@ public class ModConfig {
             }
             swimOutTick = Mth.clamp(swimOutTick, 0, 40);
             bindResultRetentionFrames = Math.max(bindResultRetentionFrames, 0);
+            activeConfigIndex = Math.max(activeConfigIndex, 0);
             displacementSmoothFactor = Mth.clamp(displacementSmoothFactor, 0.0, 1.0);
             rotationSmoothFactor = Mth.clamp(rotationSmoothFactor, 0.0, 1.0);
             if (disableMainFeatureItems == null) disableMainFeatureItems = List.of();

--- a/common/src/main/java/com/xtracr/realcamera/gui/ModelAnalyser.java
+++ b/common/src/main/java/com/xtracr/realcamera/gui/ModelAnalyser.java
@@ -141,7 +141,7 @@ public class ModelAnalyser {
                 if (!getPolygon(primitive).contains(mouseX, mouseY)) continue;
                 VertexData vertex = primitive[0];
                 float deltaZ = vertex.normalZ() == 0 ? 0 : (vertex.normalX() * (mouseX - vertex.x()) + vertex.normalY() * (mouseY - vertex.y())) / vertex.normalZ();
-                sortByZ.add(new Object[]{record, primitive, vertex.z() - deltaZ});
+                sortByZ.add(new Object[]{record, primitive, vertex.z() + deltaZ});
             }
         }
         if (sortByZ.isEmpty()) return;

--- a/common/src/main/java/com/xtracr/realcamera/gui/ModelAnalyser.java
+++ b/common/src/main/java/com/xtracr/realcamera/gui/ModelAnalyser.java
@@ -98,7 +98,7 @@ public class ModelAnalyser {
                 primitiveFor:
                 for (VertexData vertex : primitive) {
                     for (DisableConfig config : disableConfigs) {
-                        if (config.test(vertex)) continue primitiveFor;
+                        if (config.disable(vertex)) continue primitiveFor;
                     }
                     primitives.add(primitive);
                     break;
@@ -141,7 +141,7 @@ public class ModelAnalyser {
                 if (!getPolygon(primitive).contains(mouseX, mouseY)) continue;
                 VertexData vertex = primitive[0];
                 float deltaZ = vertex.normalZ() == 0 ? 0 : (vertex.normalX() * (mouseX - vertex.x()) + vertex.normalY() * (mouseY - vertex.y())) / vertex.normalZ();
-                sortByZ.add(new Object[]{record, primitive, vertex.z() + deltaZ});
+                sortByZ.add(new Object[]{record, primitive, vertex.z() - deltaZ});
             }
         }
         if (sortByZ.isEmpty()) return;

--- a/common/src/main/java/com/xtracr/realcamera/mixin/MixinLevelRenderer.java
+++ b/common/src/main/java/com/xtracr/realcamera/mixin/MixinLevelRenderer.java
@@ -28,10 +28,8 @@ public abstract class MixinLevelRenderer {
         if (!RealCameraCore.isRendering()) return;
         MultiBufferSource.BufferSource bufferSource = renderBuffers.bufferSource();
         if (!ConfigFile.config().isClassic()) {
-            Matrix4f modelView = new Matrix4f(poseStack.last().pose());
-            RealCameraCore.renderCameraEntity(minecraft, deltaTick, bufferSource, modelView);
-        }
-        else {
+            RealCameraCore.renderCameraEntity(minecraft, deltaTick, bufferSource);
+        } else {
             Vec3 cameraPos = camera.getPosition();
             renderEntity(camera.getEntity(), cameraPos.x(), cameraPos.y(), cameraPos.z(), deltaTick, poseStack, bufferSource);
         }

--- a/common/src/main/java/com/xtracr/realcamera/mixin/MixinLevelRenderer.java
+++ b/common/src/main/java/com/xtracr/realcamera/mixin/MixinLevelRenderer.java
@@ -27,7 +27,10 @@ public abstract class MixinLevelRenderer {
     private void realcamera$renderCameraEntity(PoseStack poseStack, float deltaTick, long limitTime, boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer, LightTexture lightTexture, Matrix4f matrix4f, CallbackInfo ci) {
         if (!RealCameraCore.isRendering()) return;
         MultiBufferSource.BufferSource bufferSource = renderBuffers.bufferSource();
-        if (!ConfigFile.config().isClassic()) RealCameraCore.renderCameraEntity(minecraft, deltaTick, bufferSource);
+        if (!ConfigFile.config().isClassic()) {
+            Matrix4f modelView = new Matrix4f(poseStack.last().pose());
+            RealCameraCore.renderCameraEntity(minecraft, deltaTick, bufferSource, modelView);
+        }
         else {
             Vec3 cameraPos = camera.getPosition();
             renderEntity(camera.getEntity(), cameraPos.x(), cameraPos.y(), cameraPos.z(), deltaTick, poseStack, bufferSource);


### PR DESCRIPTION
• 已回移植

  - common/src/main/java/com/xtracr/realcamera/config/BindTarget.java
    - DisableConfig 改为带 UV 缓存的 class + @JsonAdapter
    - JSON 结构保持兼容
    - 新增 disable(...)：缓存判定并用可变 FloatOpenHashSet 适配 1.20.1

  - common/src/main/java/com/xtracr/realcamera/RealCameraCore.java
    - 禁用判定统一用 config.disable(...)
    - 保留 1.20.1 view-space 渲染与 vertex.z() 深度裁剪（未引入 modelView 路径）

  - common/src/main/java/com/xtracr/realcamera/mixin/MixinLevelRenderer.java
    - 保持 1.20.1 renderLevel 注入签名与调用路径
    - 不从 PoseStack 提取 modelView

  - common/src/main/java/com/xtracr/realcamera/gui/ModelAnalyser.java
    - 修复 deltaZ 符号导致的选面排序不稳定
    - 禁用判定统一用 config.disable(...)

  - common/src/main/java/com/xtracr/realcamera/config/ModConfig.java
    - activeConfigIndex 增加下界保护（<=0 返回全部，并 clamp 到 >=0）


• 未同步

  - 平台/构建与模块迁移（Java 21、NeoForge、Gradle/Loom/Wrapper、CI 与模板）未引入：
    - build.gradle
    - settings.gradle
    - gradle.properties
    - gradle/wrapper/
    - gradlew
    - gradlew.bat
    - .github/workflows/
    - .github/ISSUE_TEMPLATE/
    - forge/
    - neoforge/
    - fabric/build.gradle
    - fabric/src/main/resources/fabric.mod.json

  - 新渲染管线与顶点 API（MeshData、ByteBufferBuilder、VertexConsumer.addVertex、FastColor）未回移：（1.20.1 没这些类与接口语义）
    - common/src/main/java/com/xtracr/realcamera/util/BuiltIterableBuffer.java
    - common/src/main/java/com/xtracr/realcamera/util/IterableVertexBuffer.java
    - common/src/main/java/com/xtracr/realcamera/util/MultiVertexCatcher.java
    - common/src/main/java/com/xtracr/realcamera/util/VertexData.java
    - common/src/main/java/com/xtracr/realcamera/gui/GUIHelper.java
    - common/src/main/java/com/xtracr/realcamera/gui/ModelViewScreen.java
    - common/src/main/java/com/xtracr/realcamera/gui/ModelAnalyser.java
    - common/src/main/java/com/xtracr/realcamera/gui/TexturedButton.java
    - common/src/main/java/com/xtracr/realcamera/gui/NumberField.java
    - common/src/main/java/com/xtracr/realcamera/gui/CyclingTexturedButton.java

  - 渲染循环与 mixin 签名变更（DeltaTracker、modelView/projection、TickRateManager、交互距离、roll 注入）及配置更新未回移：（1.20.1 没有新接口）
    - common/src/main/java/com/xtracr/realcamera/mixin/MixinGameRenderer.java
    - common/src/main/java/com/xtracr/realcamera/mixin/MixinLevelRenderer.java
    - common/src/main/java/com/xtracr/realcamera/mixin/MixinGui.java
    - common/src/main/java/com/xtracr/realcamera/RealCameraCore.java
    - common/src/main/resources/realcamera-common.mixins.json
    - common/src/main/resources/realcamera.accesswidener
    - fabric/src/main/resources/realcamera.mixins.json
    - fabric/src/main/java/com/xtracr/realcamera/EventHandler.java
    - fabric/src/main/java/com/xtracr/realcamera/mixin/GameRendererEvents.java

  - Java 21 API/语言特性依赖未回移（Math.clamp、SequencedMap、List.getFirst/removeFirst、record pattern）：
    - common/src/main/java/com/xtracr/realcamera/config/ModConfig.java
    - common/src/main/java/com/xtracr/realcamera/util/MultiVertexCatcher.java
    - common/src/main/java/com/xtracr/realcamera/gui/ModelAnalyser.java
    - common/src/main/java/com/xtracr/realcamera/util/VertexData.java

  - 经典视角/渲染器签名调整未回移（Z 方向反号、move float、PlayerRendererAccessor 额外缩放参数）：
    - common/src/main/java/com/xtracr/realcamera/mixin/MixinCamera.java
    - common/src/main/java/com/xtracr/realcamera/compat/LegacyBindingMode.java
    - common/src/main/java/com/xtracr/realcamera/mixin/accessor/PlayerRendererAccessor.java
    - common/src/main/java/com/xtracr/realcamera/mixin/MixinPlayerRenderer.java

  - 兼容层与渲染重定向差异未回移（TACZ 兼容删除、ResourceLocation.parse、YSMCompat 不再处理 normal、钓鱼线手部渲染签名变化）：
    - common/src/main/java/com/xtracr/realcamera/compat/CompatibilityHelper.java
    - common/src/main/java/com/xtracr/realcamera/compat/DisableHelper.java
    - common/src/main/java/com/xtracr/realcamera/compat/YSMCompat.java
    - common/src/main/java/com/xtracr/realcamera/mixin/MixinFishingHookRenderer.java
