### PR TITLE
[codex] Fix model view config interactions

### DIFF
--- a/common/src/main/java/com/xtracr/realcamera/gui/ModelViewScreen.java
+++ b/common/src/main/java/com/xtracr/realcamera/gui/ModelViewScreen.java
@@ -45,6 +45,7 @@ public final class ModelViewScreen extends Screen {
     private static final int SELECTION_COLOR = 0x4F3333CC, SELECTION_HOVER_COLOR = 0x2F3333CC, OUTLINE_COLOR = 0xAAFFFFFF;
     private static final int SIDE_PANEL_BG = 0xFF444444, CENTER_PANEL_BG = 0xFF222222;
     private static final int DEFAULT_SCALE = 80, MIN_SCALE = 16, MAX_SCALE = 1024;
+    private static final int CONFIG_NAME_MAX_LENGTH = 20;
     private final int xSize = 450, ySize = 206, middleWidth = xSize - 200, widgetWidth = (xSize - middleWidth) / 4 - 8, widgetHeight = 18, wideWidgetWidth = widgetWidth * 2 + 4, compactWidgetWidth = widgetWidth * 2 - 18;
     private int x, y, page = 0;
     private InputConstants.Key modifierKey = InputConstants.getKey(ConfigFile.config().binding.screenModifierKey);
@@ -60,9 +61,9 @@ public final class ModelViewScreen extends Screen {
     @Nullable
     private UVRectangleWidget focusedRectWidget;
     private final StringWidget rectWidgetsSizeWidget = new StringWidget(widgetWidth - 22, widgetHeight, CommonComponents.EMPTY, font);
-    private final EditBox nameField = createTextField(wideWidgetWidth, 20);
+    private final EditBox nameField = createTextField(wideWidgetWidth, CONFIG_NAME_MAX_LENGTH);
     private final EditBox textureIdField = createTextField(wideWidgetWidth, 1024);
-    private final EditBox disabledNameField = createTextField(compactWidgetWidth, 20);
+    private final EditBox disabledNameField = createTextField(compactWidgetWidth, CONFIG_NAME_MAX_LENGTH);
     private final EditBox disabledIdField = createTextField(wideWidgetWidth, 1024);
     private final NumberField<Integer> priorityField = NumberField.ofInt(font, widgetWidth - 2, widgetHeight - 2, 0, null);
     private final NumberField<Integer> focusedRectWidgetNumberField = NumberField.ofInt(font, widgetWidth - 2, widgetHeight - 2, 0, null).setMin(0);
@@ -255,14 +256,21 @@ public final class ModelViewScreen extends Screen {
                 button.setTooltip(Tooltip.create(LocUtil.MODEL_VIEW_TOOLTIP("emptyName").withStyle(ChatFormatting.RED)));
                 return;
             }
+            if (textureIdField.getValue().isBlank()) {
+                button.setTooltip(Tooltip.create(LocUtil.MODEL_VIEW_TOOLTIP("emptyTextureId").withStyle(ChatFormatting.RED)));
+                return;
+            }
+            if (toggleCategoryButton.getValue() == Category.DISABLE && !syncDisableDraft(button, true)) return;
             button.setTooltip(null);
             BindTarget bindTarget = genBindTarget();
             ConfigFile.config().putBindTarget(bindTarget);
             ConfigFile.save();
-            loadBindTarget(bindTarget);
             initWidgets(page);
         }));
         rows.addChild(priorityField, smallSettings).setTooltip(createTooltip("priority"));
+        boolean editableName = toggleCategoryButton.getValue() == Category.CONFIGS;
+        nameField.setEditable(editableName);
+        if (!editableName && nameField.isFocused()) nameField.setFocused(false);
         rows.addChild(nameField, 2, smallSettings).setTooltip(createTooltip("targetName"));
         grid.arrangeElements();
         FrameLayout.alignInRectangle(grid, x, y + 2, x + (xSize - middleWidth) / 2 - 4, y + ySize, 0, 0);
@@ -284,22 +292,8 @@ public final class ModelViewScreen extends Screen {
             size = disableConfigs.size();
             rows.addChild(disabledNameField, 3, smallSettings).setTooltip(createTooltip("disabledName"));
             rows.addChild(new SimpleIconButton(64, 0, button -> {
-                String name = disabledNameField.getValue(), textureId = disabledIdField.getValue();
-                if (name.isBlank()) {
-                    button.setTooltip(Tooltip.create(LocUtil.MODEL_VIEW_TOOLTIP("emptyName").withStyle(ChatFormatting.RED)));
-                } else if (textureId.isBlank()) {
-                    button.setTooltip(Tooltip.create(LocUtil.MODEL_VIEW_TOOLTIP("emptyTextureId").withStyle(ChatFormatting.RED)));
-                } else {
+                if (syncDisableDraft(button, false)) {
                     button.setTooltip(createTooltip("saveAs"));
-                    DisableConfig disableConfig = new DisableConfig(name, textureId, disableModeButton.getValue() == 0, rectWidgets.stream().map(UVRectangleWidget::toUVRectangle).toList());
-                    for (int i = 0; i < disableConfigs.size(); i++) {
-                        if (disableConfigs.get(i).name().equals(name)) {
-                            disableConfigs.set(i, disableConfig);
-                            initWidgets(page);
-                            return;
-                        }
-                    }
-                    disableConfigs.add(disableConfig);
                     initWidgets(page);
                 }
             }), smallSettings).setTooltip(createTooltip("saveAs"));
@@ -314,16 +308,13 @@ public final class ModelViewScreen extends Screen {
                         })
                         .setPosition(x + (xSize + middleWidth) / 2 - 20, y + 5 + (widgetHeight + 2) * (2 + i % widgetsPerPage));
                 rows.addChild(createButton(LocUtil.literal(config.name()), compactWidgetWidth, _ -> {
-                    disabledNameField.setValue(config.name());
-                    disabledIdField.setValue(config.textureId());
-                    disableModeButton.setValue(config.disableAll() ? 0 : 1);
-                    rectWidgets.clear();
-                    for (UVRectangle rect : config.rectangles()) rectWidgets.add(createRectWidget(rect));
+                    loadDisableConfig(config);
                     initWidgets(page);
                 }), 3).setTooltip(Tooltip.create(LocUtil.literal(config.name())));
                 rows.addChild(new SimpleIconButton(48, 0, _ -> {
                     disableConfigs.removeIf(disableConfig -> disableConfig.name().equals(config.name()));
-                    if (disabledNameField.getValue().equals(config.name())) rectWidgets.clear();
+                    hiddenNameMap.values().forEach(names -> names.remove(config.name()));
+                    if (disabledNameField.getValue().equals(config.name())) clearDisableDraft();
                     initWidgets(page * widgetsPerPage > size - 2 && size > 1 ? page - 1 : page);
                 }), smallSettings);
             }
@@ -335,6 +326,7 @@ public final class ModelViewScreen extends Screen {
             size = fixedTargetCount + targetList.size();
             for (int i = page * widgetsPerPage; i < Math.min((page + 1) * widgetsPerPage, size); i++) {
                 BindTarget target = i < fixedTargetCount ? fixedTargetList.get(i) : targetList.get(i - fixedTargetCount);
+                final int targetIndex = i;
                 String name = target.name();
                 rows.addChild(createButton(LocUtil.literal(name), compactWidgetWidth, _ -> loadBindTarget(target)), 3)
                         .setTooltip(Tooltip.create(name.equals(RealCameraCore.currentTarget().name()) ?
@@ -345,6 +337,7 @@ public final class ModelViewScreen extends Screen {
                 rows.addChild(new SimpleIconButton(48, 0, _ -> {
                     targetList.remove(target);
                     ConfigFile.save();
+                    if (nameField.getValue().equals(target.name())) loadAdjacentBindTarget(fixedTargetList, targetList, targetIndex);
                     initWidgets(page * widgetsPerPage > size - 2 && size > 1 ? page - 1 : page);
                 }), smallSettings);
             }
@@ -526,6 +519,123 @@ public final class ModelViewScreen extends Screen {
         }
     }
 
+    private void clearDisableDraft() {
+        disabledNameField.setValue("");
+        disabledIdField.setValue("");
+        focusedRectWidget = null;
+        rectWidgets.clear();
+        focusedRectWidgetNumberField.setMax(0);
+        focusedRectWidgetNumberField.setNumber(0);
+        rectWidgetsSizeWidget.setMessage(LocUtil.literal("0"));
+        uMinField.setNumber(0f);
+        vMinField.setNumber(0f);
+        uMaxField.setNumber(0f);
+        vMaxField.setNumber(0f);
+    }
+
+    private void loadDisableConfig(DisableConfig config) {
+        disabledNameField.setValue(config.name());
+        disabledIdField.setValue(config.textureId());
+        disableModeButton.setValue(config.disableAll() ? 0 : 1);
+        focusedRectWidget = null;
+        rectWidgets.clear();
+        for (UVRectangle rect : config.rectangles()) rectWidgets.add(createRectWidget(rect));
+        focusedRectWidgetNumberField.setMax(rectWidgets.size());
+        focusedRectWidgetNumberField.setNumber(0);
+        rectWidgetsSizeWidget.setMessage(LocUtil.literal(String.valueOf(rectWidgets.size())));
+    }
+
+    private boolean syncDisableDraft(Button button, boolean autoName) {
+        String name = disabledNameField.getValue();
+        String textureId = disabledIdField.getValue();
+        if (name.isBlank()) {
+            if (!autoName) {
+                button.setTooltip(Tooltip.create(LocUtil.MODEL_VIEW_TOOLTIP("emptyName").withStyle(ChatFormatting.RED)));
+                return false;
+            }
+            if (!hasMeaningfulDisableDraft()) {
+                if (textureId.isBlank() && !rectWidgets.isEmpty()) {
+                    button.setTooltip(Tooltip.create(LocUtil.MODEL_VIEW_TOOLTIP("emptyTextureId").withStyle(ChatFormatting.RED)));
+                    return false;
+                }
+                return true;
+            }
+            name = generateDisableConfigName(textureId);
+            disabledNameField.setValue(name);
+        }
+        if (textureId.isBlank()) {
+            button.setTooltip(Tooltip.create(LocUtil.MODEL_VIEW_TOOLTIP("emptyTextureId").withStyle(ChatFormatting.RED)));
+            return false;
+        }
+        DisableConfig disableConfig = new DisableConfig(name, textureId, disableModeButton.getValue() == 0, rectWidgets.stream().map(UVRectangleWidget::toUVRectangle).toList());
+        upsertDisableConfig(disableConfig);
+        return true;
+    }
+
+    private boolean hasMeaningfulDisableDraft() {
+        return !disabledIdField.getValue().isBlank() && (disableModeButton.getValue() == 0 || !rectWidgets.isEmpty());
+    }
+
+    private void upsertDisableConfig(DisableConfig disableConfig) {
+        for (int i = 0; i < disableConfigs.size(); i++) {
+            if (disableConfigs.get(i).name().equals(disableConfig.name())) {
+                disableConfigs.set(i, disableConfig);
+                return;
+            }
+        }
+        disableConfigs.add(disableConfig);
+    }
+
+    private String generateDisableConfigName(String textureId) {
+        String base = textureId.trim();
+        int separatorIndex = Math.max(base.lastIndexOf('/'), base.lastIndexOf(':'));
+        if (separatorIndex >= 0 && separatorIndex < base.length() - 1) base = base.substring(separatorIndex + 1);
+        int extensionIndex = base.lastIndexOf('.');
+        if (extensionIndex > 0) base = base.substring(0, extensionIndex);
+        base = sanitizeDisableConfigName(base);
+        if (base.length() > CONFIG_NAME_MAX_LENGTH) base = base.substring(0, CONFIG_NAME_MAX_LENGTH);
+
+        String candidate = base;
+        for (int suffix = 2; disableConfigNameExists(candidate); suffix++) {
+            String suffixText = "_" + suffix;
+            int baseLength = Math.min(base.length(), Math.max(1, CONFIG_NAME_MAX_LENGTH - suffixText.length()));
+            candidate = base.substring(0, baseLength) + suffixText;
+        }
+        return candidate;
+    }
+
+    private String sanitizeDisableConfigName(String name) {
+        StringBuilder builder = new StringBuilder();
+        boolean lastWasSeparator = false;
+        for (int i = 0; i < name.length(); i++) {
+            char c = Character.toLowerCase(name.charAt(i));
+            if (Character.isLetterOrDigit(c)) {
+                builder.append(c);
+                lastWasSeparator = false;
+            } else if ((c == '_' || c == '-') && builder.length() > 0 && !lastWasSeparator) {
+                builder.append(c);
+                lastWasSeparator = true;
+            } else if (builder.length() > 0 && !lastWasSeparator) {
+                builder.append('_');
+                lastWasSeparator = true;
+            }
+        }
+        while (!builder.isEmpty() && (builder.charAt(builder.length() - 1) == '_' || builder.charAt(builder.length() - 1) == '-'))
+            builder.deleteCharAt(builder.length() - 1);
+        return builder.isEmpty() ? "disable" : builder.toString();
+    }
+
+    private boolean disableConfigNameExists(String name) {
+        return disableConfigs.stream().anyMatch(disableConfig -> disableConfig.name().equals(name));
+    }
+
+    private void loadAdjacentBindTarget(List<BindTarget> fixedTargetList, List<BindTarget> targetList, int deletedIndex) {
+        List<BindTarget> targets = new ArrayList<>(fixedTargetList);
+        targets.addAll(targetList);
+        if (targets.isEmpty()) loadBindTarget(BindTarget.blank("", ""));
+        else loadBindTarget(targets.get(Math.min(deletedIndex, targets.size() - 1)));
+    }
+
     private void loadBindTarget(BindTarget target) {
         if (target.isEmpty()) return;
         nameField.setValue(target.name());
@@ -552,19 +662,14 @@ public final class ModelViewScreen extends Screen {
         offsetRollPair.setNumber(offsets.roll);
         disableConfigs.clear();
         disableConfigs.addAll(target.disableConfigs());
+        clearDisableDraft();
     }
 
     private BindTarget genBindTarget() {
         TargetConfig targetConfig = new TargetConfig(forwardUField.getNumber(), forwardVField.getNumber(), upwardUField.getNumber(), upwardVField.getNumber(), posUField.getNumber(), posVField.getNumber());
         BindConfig bindConfig = new BindConfig(bindXButton.getValue() == 0, bindYButton.getValue() == 0, bindZButton.getValue() == 0, bindRotButton.getValue() == 0);
         OffsetConfig offsets = new OffsetConfig(scaleField.getNumber(), offsetXPair.getNumber(), offsetYPair.getNumber(), offsetZPair.getNumber(), offsetPitchPair.getNumber(), offsetYawPair.getNumber(), offsetRollPair.getNumber());
-        DisableConfig currentDisableConfig = new DisableConfig(disabledNameField.getValue(), disabledIdField.getValue(), disableModeButton.getValue() == 0, rectWidgets.stream().map(UVRectangleWidget::toUVRectangle).toList());
-        List<DisableConfig> newDisableConfigs = new ArrayList<>(disableConfigs);
-        for (int i = 0; i < newDisableConfigs.size(); i++) {
-            if (newDisableConfigs.get(i).name().equals(currentDisableConfig.name()))
-                newDisableConfigs.set(i, currentDisableConfig);
-        }
-        return new BindTarget(nameField.getValue(), textureIdField.getValue(), priorityField.getNumber(), depthField.getNumber(), targetConfig, bindConfig, offsets, newDisableConfigs);
+        return new BindTarget(nameField.getValue(), textureIdField.getValue(), priorityField.getNumber(), depthField.getNumber(), targetConfig, bindConfig, offsets, new ArrayList<>(disableConfigs));
     }
 
     private UVRectangleWidget addRectWidget(UVRectangleWidget rectWidget) {

--- a/common/src/main/resources/assets/realcamera/lang/be_by.json
+++ b/common/src/main/resources/assets/realcamera/lang/be_by.json
@@ -91,7 +91,7 @@
   "screen.tooltip.xtracr_realcamera.modelView_importSucceeded": "Імпарт %s паспяховы!",
   "screen.tooltip.xtracr_realcamera.modelView_preview": "У рэжыме прадпрагляду вы можаце наладжваць зрух і паварот камеры",
   "screen.tooltip.xtracr_realcamera.modelView_priority": "Прыярытэт пры прывязцы, чым больш значэнне, тым вышэй прыярытэт і размяшчэнне справей у спісе",
-  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "Захаваць як\n(Калі існуе канфігурацыя з такой жа назвай, вы таксама можаце націснуць кнопку захавання злева)",
+  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "Дадаць/абнавіць гэту наладу адключэння\nНацісніце Захаваць злева, каб захаваць канфігурацыю",
   "screen.tooltip.xtracr_realcamera.modelView_scale": "Маштаб, які кіруе памерам зрухаў",
   "screen.tooltip.xtracr_realcamera.modelView_selecting": "%s+Левы клік каб атрымаць UV-каардынаты пад паказальнікам мышы\nТры наборы UV-каардынат ніжэй, зверху ўніз, гэта UV-каардынаты вектара наперад, вектара уверх і пункту прывязкі на мэтавай плоскасці\nЗаўвага: %s+Пракрутка каб пераключацца паміж рознымі слаямі мадэлі. Увод UV-каардынат уручную дазваляе дакладней прывязацца да мэтавай пазіцыі",
   "screen.tooltip.xtracr_realcamera.modelView_selectionMode": "Вызначае рэжым хуткага выбару %s+Левы клік\n(%s+Пракрутка каб змяніць дыяпазон выбару ў рэжыме дыяпазону)",

--- a/common/src/main/resources/assets/realcamera/lang/en_us.json
+++ b/common/src/main/resources/assets/realcamera/lang/en_us.json
@@ -91,7 +91,7 @@
   "screen.tooltip.xtracr_realcamera.modelView_importSucceeded": "Import %s succeeded!",
   "screen.tooltip.xtracr_realcamera.modelView_preview": "In the preview mode, you can adjust the camera's offset and rotation",
   "screen.tooltip.xtracr_realcamera.modelView_priority": "Priority when binding, the larger the value the higher the priority, and the higher the sorting on the right side",
-  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "Save as\n(When there is a setting with the same name, you can also press the save button on the left)",
+  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "Add/update this disable setting\nPress Save on the left to save the config",
   "screen.tooltip.xtracr_realcamera.modelView_scale": "Scale, which controls the size of the offsets",
   "screen.tooltip.xtracr_realcamera.modelView_selecting": "%s+Left Click to get the UV coordinates at the mouse pointer\nThe three sets of UV coordinates below are, from top to bottom, the UV coordinates of the forward vector, the upward vector, and the binding point on the target plane\nNote: %s+Scroll to switch between the different layers of the model. Manually inputting UV coordinates allows you to bind more accurately to the target position",
   "screen.tooltip.xtracr_realcamera.modelView_selectionMode": "Decide the mode of %s+Left Click quick selection\n(%s+Scroll to change the selection range in the range mode)",

--- a/common/src/main/resources/assets/realcamera/lang/es_es.json
+++ b/common/src/main/resources/assets/realcamera/lang/es_es.json
@@ -91,7 +91,7 @@
   "screen.tooltip.xtracr_realcamera.modelView_importSucceeded": "¡Importación %s exitosa!",
   "screen.tooltip.xtracr_realcamera.modelView_preview": "En el modo de vista previa, puedes ajustar el desplazamiento y rotación de la cámara",
   "screen.tooltip.xtracr_realcamera.modelView_priority": "Prioridad al vincular, cuanto mayor sea el valor, mayor será la prioridad y más alto será el orden en el lado derecho",
-  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "Guardar como\n(Cuando existe una configuración con el mismo nombre, también puede usar el botón guardar a la izquierda)",
+  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "Añadir/actualizar este ajuste de desactivación\nPulsa Guardar a la izquierda para guardar la configuración",
   "screen.tooltip.xtracr_realcamera.modelView_scale": "Escala, que controla el tamaño de los desplazamientos",
   "screen.tooltip.xtracr_realcamera.modelView_selecting": "%s+Clic izquierdo para obtener las coordenadas UV en el puntero del ratón\nLos tres conjuntos de coordenadas UV a continuación son, de arriba a abajo, las coordenadas UV del vector adelante, el vector arriba y el punto de vinculación en el plano objetivo\nNota: %s+Desplazarse para cambiar entre las diferentes capas del modelo. Ingresar manualmente las coordenadas UV permite vincular con mayor precisión a la posición objetivo",
   "screen.tooltip.xtracr_realcamera.modelView_selectionMode": "Determina el modo de selección rápida %s+Clic izquierdo\n(%s+Desplazarse para cambiar el rango de selección en el modo de rango)",

--- a/common/src/main/resources/assets/realcamera/lang/fr_fr.json
+++ b/common/src/main/resources/assets/realcamera/lang/fr_fr.json
@@ -91,7 +91,7 @@
   "screen.tooltip.xtracr_realcamera.modelView_importSucceeded": "Importation %s réussie !",
   "screen.tooltip.xtracr_realcamera.modelView_preview": "En mode aperçu, vous pouvez ajuster le décalage et la rotation de la caméra",
   "screen.tooltip.xtracr_realcamera.modelView_priority": "Priorité lors de la liaison, plus la valeur est grande, plus la priorité est élevée et plus le tri est haut sur le côté droit",
-  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "Enregistrer sous\n(Lorsqu'il existe une configuration avec le même nom, vous pouvez également utiliser le bouton enregistrer à gauche)",
+  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "Ajouter/mettre à jour ce paramètre de désactivation\nCliquez sur Enregistrer à gauche pour enregistrer la configuration",
   "screen.tooltip.xtracr_realcamera.modelView_scale": "Échelle, qui contrôle la taille des décalages",
   "screen.tooltip.xtracr_realcamera.modelView_selecting": "%s+Clic gauche pour obtenir les coordonnées UV au niveau du pointeur de la souris\nLes trois ensembles de coordonnées UV ci-dessous sont, de haut en bas, les coordonnées UV du vecteur avant, du vecteur haut et du point de liaison sur le plan cible\nNote : %s+Défilement pour basculer entre les différentes couches du modèle. La saisie manuelle des coordonnées UV permet de se lier plus précisément à la position cible",
   "screen.tooltip.xtracr_realcamera.modelView_selectionMode": "Détermine le mode de sélection rapide %s+Clic gauche\n(%s+Défilement pour changer la plage de sélection en mode plage)",

--- a/common/src/main/resources/assets/realcamera/lang/ja_jp.json
+++ b/common/src/main/resources/assets/realcamera/lang/ja_jp.json
@@ -91,7 +91,7 @@
   "screen.tooltip.xtracr_realcamera.modelView_importSucceeded": "%sのインポートに成功しました！",
   "screen.tooltip.xtracr_realcamera.modelView_preview": "プレビューモードでカメラの様々なオフセットを調整できます",
   "screen.tooltip.xtracr_realcamera.modelView_priority": "バインディング時の優先度、値が大きいほど優先度が高く右側のソートで上位に表示",
-  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "名前を付けて保存\n（同名設定がある場合も左の保存ボタンを使用できます）",
+  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "この無効化設定を追加/更新\n左の保存を押して設定を保存",
   "screen.tooltip.xtracr_realcamera.modelView_scale": "スケール、オフセットのサイズを制御",
   "screen.tooltip.xtracr_realcamera.modelView_selecting": "%s+左クリックでマウスポインタ位置のUV座標を取得\n下の3組のUV座標は上から順に前方ベクトル、上方ベクトル、ターゲット平面上のバインディング点のUV座標\n注: %s+スクロールでモデルの異なるレイヤー間を切り替えられます。手動でUV座標を入力するとターゲット位置に正確にバインドできます",
   "screen.tooltip.xtracr_realcamera.modelView_selectionMode": "%s+左クリッククイック選択のモードを決定\n（%s+スクロールで範囲モードの選択範囲を変更）",

--- a/common/src/main/resources/assets/realcamera/lang/ko_kr.json
+++ b/common/src/main/resources/assets/realcamera/lang/ko_kr.json
@@ -91,7 +91,7 @@
   "screen.tooltip.xtracr_realcamera.modelView_importSucceeded": "%s 가져오기 성공!",
   "screen.tooltip.xtracr_realcamera.modelView_preview": "미리보기 모드에서 카메라의 다양한 오프셋 조정 가능",
   "screen.tooltip.xtracr_realcamera.modelView_priority": "바인딩 시 우선순위, 값이 클수록 우선순위가 높으며 오른쪽 정렬에서 위쪽에 표시",
-  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "다른 이름으로 저장\n(동일 이름 설정이 있을 때 왼쪽 저장 버튼도 사용 가능)",
+  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "이 비활성화 설정 추가/업데이트\n왼쪽 저장을 눌러 구성을 저장",
   "screen.tooltip.xtracr_realcamera.modelView_scale": "크기 조절, 오프셋 크기 제어",
   "screen.tooltip.xtracr_realcamera.modelView_selecting": "%s+왼쪽 클릭으로 마우스 포인터 위치의 UV 좌표 얻기\n아래 세 가지 UV 좌표는 위에서부터 전방 벡터, 상향 벡터, 대상 평면의 바인딩 지점 UV 좌표입니다\n참고: %s+스크롤로 모델의 다른 레이어 간 전환, 수동 UV 좌표 입력으로 대상 위치에 더 정확하게 바인딩 가능",
   "screen.tooltip.xtracr_realcamera.modelView_selectionMode": "%s+왼쪽 클릭 빠른 선택 모드 결정\n(%s+스크롤로 범위 모드에서 선택 범위 변경)",

--- a/common/src/main/resources/assets/realcamera/lang/lzh.json
+++ b/common/src/main/resources/assets/realcamera/lang/lzh.json
@@ -91,7 +91,7 @@
   "screen.tooltip.xtracr_realcamera.modelView_importSucceeded": "入%s成！",
   "screen.tooltip.xtracr_realcamera.modelView_preview": "於覽式可調鏡觀諸偏移",
   "screen.tooltip.xtracr_realcamera.modelView_priority": "系定之先級，值愈大愈先，且右列愈前",
-  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "存為\n（當有同名設時，亦可用左存鈕）",
+  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "增/更新此禁用設\n再按左存鈕以存目前設",
   "screen.tooltip.xtracr_realcamera.modelView_scale": "縮放之度，控偏移量之大小",
   "screen.tooltip.xtracr_realcamera.modelView_selecting": "%s+左鍵可取光標處UV座標\n下三組UV座標自上而下為前向矢、上向矢與的平面上系點之UV座標\n註：%s鍵+滾輪可易模型之層，手輸UV座標可精系的位",
   "screen.tooltip.xtracr_realcamera.modelView_selectionMode": "定%s+左鍵速擇之法\n（%s鍵+滾輪可易域擇之範）",

--- a/common/src/main/resources/assets/realcamera/lang/pl_pl.json
+++ b/common/src/main/resources/assets/realcamera/lang/pl_pl.json
@@ -91,7 +91,7 @@
   "screen.tooltip.xtracr_realcamera.modelView_importSucceeded": "Import %s powiódł się!",
   "screen.tooltip.xtracr_realcamera.modelView_preview": "W trybie podglądu możesz dostosować przesunięcie i obrót kamery",
   "screen.tooltip.xtracr_realcamera.modelView_priority": "Priorytet powiązania: im większa wartość, tym wyższy priorytet i wyższe sortowanie po prawej stronie",
-  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "Zapisz jako\n(Gdy istnieje konfiguracja o tej samej nazwie, możesz również użyć przycisku zapisu po lewej stronie)",
+  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "Dodaj/zaktualizuj to ustawienie wyłączenia\nKliknij Zapisz po lewej, aby zapisać konfigurację",
   "screen.tooltip.xtracr_realcamera.modelView_scale": "Skala, która kontroluje rozmiar przesunięć",
   "screen.tooltip.xtracr_realcamera.modelView_selecting": "%s+LKliknij, aby uzyskać współrzędne UV w miejscu wskaźnika myszy\nTrzy zestawy współrzędnych UV poniżej, od góry do dołu, to współrzędne UV wektora do przodu, wektora w górę i punktu wiązania na płaszczyźnie docelowej\nUwaga: %s+Przewiń, aby przełączać się między różnymi warstwami modelu. Ręczne wprowadzanie współrzędnych UV pozwala dokładniej powiązać z pozycją docelową",
   "screen.tooltip.xtracr_realcamera.modelView_selectionMode": "Określa tryb szybkiego wyboru %s+LKliknięcia\n(%s+Przewiń, aby zmienić zakres wyboru w trybie zakresu)",

--- a/common/src/main/resources/assets/realcamera/lang/pt_br.json
+++ b/common/src/main/resources/assets/realcamera/lang/pt_br.json
@@ -91,7 +91,7 @@
   "screen.tooltip.xtracr_realcamera.modelView_importSucceeded": "Importação %s bem-sucedida!",
   "screen.tooltip.xtracr_realcamera.modelView_preview": "No modo de pré-visualização, você pode ajustar o deslocamento e rotação da câmera",
   "screen.tooltip.xtracr_realcamera.modelView_priority": "Prioridade ao vincular, quanto maior o valor maior a prioridade e maior a ordenação no lado direito",
-  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "Salvar como\n(Quando existe uma configuração com o mesmo nome, você também pode usar o botão salvar à esquerda)",
+  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "Adicionar/atualizar esta configuração de desativação\nPressione Salvar à esquerda para salvar a configuração",
   "screen.tooltip.xtracr_realcamera.modelView_scale": "Escala, que controla o tamanho dos deslocamentos",
   "screen.tooltip.xtracr_realcamera.modelView_selecting": "%s+Clique Esquerdo para obter as coordenadas UV no ponteiro do mouse\nOs três conjuntos de coordenadas UV abaixo são, de cima para baixo, as coordenadas UV do vetor de frente, do vetor para cima e do ponto de vinculação no plano alvo\nNota: %s+Rolar para alternar entre as diferentes camadas do modelo. Inserir manualmente as coordenadas UV permite vincular com mais precisão à posição alvo",
   "screen.tooltip.xtracr_realcamera.modelView_selectionMode": "Determina o modo de seleção rápida %s+Clique Esquerdo\n(%s+Rolar para alterar o intervalo de seleção no modo de intervalo)",

--- a/common/src/main/resources/assets/realcamera/lang/pt_pt.json
+++ b/common/src/main/resources/assets/realcamera/lang/pt_pt.json
@@ -91,7 +91,7 @@
   "screen.tooltip.xtracr_realcamera.modelView_importSucceeded": "Importação %s bem-sucedida!",
   "screen.tooltip.xtracr_realcamera.modelView_preview": "No modo de pré-visualização, você pode ajustar o deslocamento e rotação da câmera",
   "screen.tooltip.xtracr_realcamera.modelView_priority": "Prioridade ao vincular, quanto maior o valor maior a prioridade e maior a ordenação no lado direito",
-  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "Salvar como\n(Quando existe uma configuração com o mesmo nome, você também pode usar o botão salvar à esquerda)",
+  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "Adicionar/atualizar esta configuração de desativação\nPrima Salvar à esquerda para salvar a configuração",
   "screen.tooltip.xtracr_realcamera.modelView_scale": "Escala, que controla o tamanho dos deslocamentos",
   "screen.tooltip.xtracr_realcamera.modelView_selecting": "%s+Clique Esquerdo para obter as coordenadas UV no ponteiro do mouse\nOs três conjuntos de coordenadas UV abaixo são, de cima para baixo, as coordenadas UV do vetor de frente, do vetor para cima e do ponto de vinculação no plano alvo\nNota: %s+Rolar para alternar entre as diferentes camadas do modelo. Inserir manualmente as coordenadas UV permite vincular com mais precisão à posição alvo",
   "screen.tooltip.xtracr_realcamera.modelView_selectionMode": "Determina o modo de seleção rápida %s+Clique Esquerdo\n(%s+Rolar para alterar o intervalo de seleção no modo de intervalo)",

--- a/common/src/main/resources/assets/realcamera/lang/ru_ru.json
+++ b/common/src/main/resources/assets/realcamera/lang/ru_ru.json
@@ -91,7 +91,7 @@
   "screen.tooltip.xtracr_realcamera.modelView_importSucceeded": "Импорт %s успешен!",
   "screen.tooltip.xtracr_realcamera.modelView_preview": "В режиме предпросмотра вы можете настроить смещение и вращение камеры",
   "screen.tooltip.xtracr_realcamera.modelView_priority": "Приоритет при привязке: чем больше значение, тем выше приоритет и выше сортировка на правой стороне",
-  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "Сохранить как\n(При наличии настройки с тем же именем вы также можете использовать кнопку сохранения слева)",
+  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "Добавить/обновить эту настройку отключения\nНажмите Сохранить слева, чтобы сохранить конфигурацию",
   "screen.tooltip.xtracr_realcamera.modelView_scale": "Масштаб, который контролирует размер смещений",
   "screen.tooltip.xtracr_realcamera.modelView_selecting": "%s+Левый клик чтобы получить UV-координаты в месте указателя мыши\nТри набора UV-координат ниже, сверху вниз, это UV-координаты вектора направления, вектора вверх и точки привязки на целевой плоскости\nПримечание: %s+Прокрутка для переключения между различными слоями модели. Ручной ввод UV-координат позволяет более точно привязаться к целевой позиции",
   "screen.tooltip.xtracr_realcamera.modelView_selectionMode": "Определяет режим быстрого выбора %s+Левый клик\n(%s+Прокрутка для изменения диапазона выбора в режиме диапазона)",

--- a/common/src/main/resources/assets/realcamera/lang/tr_tr.json
+++ b/common/src/main/resources/assets/realcamera/lang/tr_tr.json
@@ -91,7 +91,7 @@
   "screen.tooltip.xtracr_realcamera.modelView_importSucceeded": "%s içe aktarma başarılı!",
   "screen.tooltip.xtracr_realcamera.modelView_preview": "Önizleme modunda kameranın çeşitli ofsetlerini ayarlayabilirsiniz",
   "screen.tooltip.xtracr_realcamera.modelView_priority": "Bağlama önceliği, değer ne kadar büyükse öncelik o kadar yüksektir ve sağ taraftaki sıralama da o kadar yukarıdadır",
-  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "Farklı Kaydet\n(Aynı isimde bir ayar olduğunda, soldaki kaydet düğmesini de kullanabilirsiniz)",
+  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "Bu devre dışı bırakma ayarını ekle/güncelle\nYapılandırmayı kaydetmek için soldaki Kaydet'e basın",
   "screen.tooltip.xtracr_realcamera.modelView_scale": "Ölçek, ofsetlerin boyutunu kontrol eder",
   "screen.tooltip.xtracr_realcamera.modelView_selecting": "%s+Sol Tık ile fare işaretçisindeki UV koordinatlarını alın\nAşağıdaki üç UV koordinat seti, yukarıdan aşağıya doğru, ileri vektör, yukarı vektör ve hedef düzlemdeki bağlama noktasının UV koordinatlarıdır\nNot: %s+Kaydırma ile modelin farklı katmanları arasında geçiş yapabilirsiniz. UV koordinatlarını manuel olarak girerek hedef konuma daha hassas bir şekilde bağlanabilirsiniz",
   "screen.tooltip.xtracr_realcamera.modelView_selectionMode": "%s+Sol Tık hızlı seçim modunu belirler\n(%s+Kaydırma ile aralık modundaki seçim aralığını değiştirin)",

--- a/common/src/main/resources/assets/realcamera/lang/uk_ua.json
+++ b/common/src/main/resources/assets/realcamera/lang/uk_ua.json
@@ -91,7 +91,7 @@
   "screen.tooltip.xtracr_realcamera.modelView_importSucceeded": "Імпорт %s успішний!",
   "screen.tooltip.xtracr_realcamera.modelView_preview": "У режимі попереднього перегляду ви можете налаштувати зміщення та обертання камери",
   "screen.tooltip.xtracr_realcamera.modelView_priority": "Пріоритет при прив'язці: чим більше значення, тим вищий пріоритет і вище сортування на правій стороні",
-  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "Зберегти як\n(При наявності налаштування з тим же ім'ям ви також можете використовувати кнопку збереження зліва)",
+  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "Додати/оновити це налаштування вимкнення\nНатисніть Зберегти ліворуч, щоб зберегти конфігурацію",
   "screen.tooltip.xtracr_realcamera.modelView_scale": "Масштаб, який контролює розмір зміщень",
   "screen.tooltip.xtracr_realcamera.modelView_selecting": "%s+Лівий клік щоб отримати UV-координати в місці вказівника миші\nТри набори UV-координат нижче, зверху вниз, це UV-координати вектора напрямку, вектора вгору та точки прив'язки на цільовій площині\nПримітка: %s+Прокрутка для перемикання між різними шарами моделі. Ручний ввід UV-координат дозволяє точніше прив'язатися до цільової позиції",
   "screen.tooltip.xtracr_realcamera.modelView_selectionMode": "Визначає режим швидкого вибору %s+Лівий клік\n(%s+Прокрутка для зміни діапазону вибору в режимі діапазону)",

--- a/common/src/main/resources/assets/realcamera/lang/zh_cn.json
+++ b/common/src/main/resources/assets/realcamera/lang/zh_cn.json
@@ -91,7 +91,7 @@
   "screen.tooltip.xtracr_realcamera.modelView_importSucceeded": "导入%s成功！",
   "screen.tooltip.xtracr_realcamera.modelView_preview": "在预览模式可以调整相机的各个偏移量",
   "screen.tooltip.xtracr_realcamera.modelView_priority": "绑定时的优先级，值越大优先级越高，并且在右侧排序越靠上",
-  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "保存为\n（当存在同名设置时，也可使用左侧保存按钮）",
+  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "添加/更新此禁用设置\n再点左侧保存以保存到当前配置",
   "screen.tooltip.xtracr_realcamera.modelView_scale": "缩放比例，控制偏移量的大小",
   "screen.tooltip.xtracr_realcamera.modelView_selecting": "%s+左键可获取鼠标指针处的UV坐标\n下方三组UV坐标由上到下依次为向前矢量、向上矢量和目标平面上绑定点的UV坐标\n注：%s键+滚轮可在模型的不同层间切换，手动输入UV坐标可以更加精确地绑定到目标位置",
   "screen.tooltip.xtracr_realcamera.modelView_selectionMode": "决定%s+左键快速选择的模式\n（%s键+滚轮可改变范围模式下的选择范围）",

--- a/common/src/main/resources/assets/realcamera/lang/zh_hk.json
+++ b/common/src/main/resources/assets/realcamera/lang/zh_hk.json
@@ -91,7 +91,7 @@
   "screen.tooltip.xtracr_realcamera.modelView_importSucceeded": "導入%s成功！",
   "screen.tooltip.xtracr_realcamera.modelView_preview": "在預覽模式可以調整相機的各個偏移量",
   "screen.tooltip.xtracr_realcamera.modelView_priority": "綁定時的優先級，值越大優先級越高，並且在右側排序越靠上",
-  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "儲存為\n（當存在同名設置時，也可使用左側儲存按鈕）",
+  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "新增/更新此禁用設定\n再按左側儲存以儲存到目前設定",
   "screen.tooltip.xtracr_realcamera.modelView_scale": "縮放比例，控制偏移量的大小",
   "screen.tooltip.xtracr_realcamera.modelView_selecting": "左Alt+左鍵可獲取鼠標指針處的UV座標\n下方三組UV座標由上到下依次為向前向量、向上向量和目標平面上綁定點的UV座標\n註：左Alt鍵+滾輪可在模型的不同層間切換，手動輸入UV座標可以更加精確地綁定到目標位置",
   "screen.tooltip.xtracr_realcamera.modelView_selectionMode": "決定左Alt+左鍵快速選擇的模式\n（左Alt鍵+滾輪可改變範圍模式下的選擇範圍）",

--- a/common/src/main/resources/assets/realcamera/lang/zh_tw.json
+++ b/common/src/main/resources/assets/realcamera/lang/zh_tw.json
@@ -91,7 +91,7 @@
   "screen.tooltip.xtracr_realcamera.modelView_importSucceeded": "導入%s成功！",
   "screen.tooltip.xtracr_realcamera.modelView_preview": "在預覽模式可以調整相機的各個偏移量",
   "screen.tooltip.xtracr_realcamera.modelView_priority": "綁定時的優先級，值越大優先級越高，並且在右側排序越靠上",
-  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "儲存為\n（當存在同名設置時，也可使用左側儲存按鈕）",
+  "screen.tooltip.xtracr_realcamera.modelView_saveAs": "新增/更新此禁用設定\n再按左側儲存以儲存到目前設定",
   "screen.tooltip.xtracr_realcamera.modelView_scale": "縮放比例，控制偏移量的大小",
   "screen.tooltip.xtracr_realcamera.modelView_selecting": "左Alt+左鍵可獲取鼠標指針處的UV座標\n下方三組UV座標由上到下依次為向前向量、向上向量和目標平面上綁定點的UV座標\n註：左Alt鍵+滾輪可在模型的不同層間切換，手動輸入UV座標可以更加精確地綁定到目標位置",
   "screen.tooltip.xtracr_realcamera.modelView_selectionMode": "決定左Alt+左鍵快速選擇的模式\n（左Alt鍵+滾輪可改變範圍模式下的選擇範圍）",


### PR DESCRIPTION
## Summary
- Tighten ModelViewScreen save semantics by validating target texture IDs and only syncing disable drafts from the disable page.
- Clear disable draft state when switching targets to prevent cross-config contamination.
- Keep PREVIEW target switching while making the target name read-only outside CONFIGS, and clean up delete flows so removed configs are not recreated accidentally.

## Validation
- `./gradlew.bat :common:test`
- `./gradlew.bat build`

## Notes
- No config schema, serialization codec, or runtime binding API changes.