### PR TITLE
Fix 1.20.1 API compatibility risks after the 26.1 sync

### DIFF
--- a/common/src/main/java/com/xtracr/realcamera/RealCameraCore.java
+++ b/common/src/main/java/com/xtracr/realcamera/RealCameraCore.java
@@ -67,7 +67,7 @@ public class RealCameraCore {
         return (float) getEulerAngle(0, 0, f).z();
     }
 
-    private static Vec3 getEulerAngle(float pitch, float yaw, float roll) {
+    public static Vec3 getEulerAngle(float pitch, float yaw, float roll) {
         if (!currentTarget().bindConfig().bindRotation()) return new Vec3(pitch, yaw, roll);
         double scale = Math.toDegrees(1);
         return MathUtil.getEulerAngleYXZ(smoothedCamera.getRotation()).multiply(scale, -scale, scale);
@@ -105,7 +105,7 @@ public class RealCameraCore {
         entity.setInvisible(invisible);
         if (newResult.available()) {
             failureFrames = 0;
-            lastResult = newResult.computeCamera(false);
+            lastResult = newResult.computeCamera();
         } else {
             failureFrames++;
             Entity player = client.player;

--- a/common/src/main/java/com/xtracr/realcamera/api/BindResult.java
+++ b/common/src/main/java/com/xtracr/realcamera/api/BindResult.java
@@ -12,7 +12,7 @@ import java.util.List;
 public class BindResult extends CameraTransform {
     public static final BindResult EMPTY = new BindResult(BindTarget.EMPTY);
     public final BindTarget target;
-    private final boolean mirrored;
+    protected final boolean mirrored;
     private Vec3 forward = Vec3.ZERO, upward = Vec3.ZERO;
 
     public BindResult(BindTarget target) {

--- a/common/src/main/java/com/xtracr/realcamera/api/BindResult.java
+++ b/common/src/main/java/com/xtracr/realcamera/api/BindResult.java
@@ -12,10 +12,16 @@ import java.util.List;
 public class BindResult extends CameraTransform {
     public static final BindResult EMPTY = new BindResult(BindTarget.EMPTY);
     public final BindTarget target;
+    private final boolean mirrored;
     private Vec3 forward = Vec3.ZERO, upward = Vec3.ZERO;
 
     public BindResult(BindTarget target) {
+        this(target, false);
+    }
+
+    public BindResult(BindTarget target, boolean mirrored) {
         this.target = target;
+        this.mirrored = mirrored;
     }
 
     public static BindResult getOrCreate(String name) {
@@ -53,6 +59,10 @@ public class BindResult extends CameraTransform {
 
     public void setUpward(Vec3 vec) {
         upward = vec.normalize();
+    }
+
+    public BindResult computeCamera() {
+        return computeCamera(mirrored);
     }
 
     public BindResult computeCamera(boolean mirrored) {

--- a/common/src/main/java/com/xtracr/realcamera/mixin/MixinCamera.java
+++ b/common/src/main/java/com/xtracr/realcamera/mixin/MixinCamera.java
@@ -54,7 +54,8 @@ public abstract class MixinCamera {
             double restrictedY = Mth.clamp(rawPos.y(), box.minY + 0.1D, box.maxY - 0.1D);
             startVec = new Vec3(position.x(), restrictedY, position.z());
             setPosition(rawPos);
-            setRotation(RealCameraCore.getYaw(yRot), RealCameraCore.getPitch(xRot));
+            Vec3 eulerAngle = RealCameraCore.getEulerAngle(xRot, yRot, 0);
+            setRotation((float) eulerAngle.y(), (float) eulerAngle.x());
         }
         realcamera$clipToSpace(startVec, entity, realcamera$getFov(deltaTick));
         RealCameraCore.setCameraPos(position);

--- a/common/src/main/java/com/xtracr/realcamera/util/CameraTransform.java
+++ b/common/src/main/java/com/xtracr/realcamera/util/CameraTransform.java
@@ -10,15 +10,15 @@ public class CameraTransform {
     protected final Matrix3f rotation = new Matrix3f();
     protected Vec3 position = Vec3.ZERO;
 
-    public final Vec3 getPosition() {
+    public Vec3 getPosition() {
         return position;
     }
 
-    public final void setPosition(Vec3 vec) {
+    public void setPosition(Vec3 vec) {
         position = vec;
     }
 
-    public final Matrix3f getRotation() {
+    public Matrix3f getRotation() {
         return rotation;
     }
 


### PR DESCRIPTION
## 背景与范围

此 PR 修复合并 26.1 实现后发现的 1.20.1 API 兼容风险，并顺带减少一次重复的相机旋转计算。

对于只使用 RealCamera 自身功能、没有依赖旧 `RealCameraAPI` 的第三方模组，并且不使用由外部 provider 提供的镜像绑定结果的玩家，合并前的代码通常不会出现可见问题。本 PR 主要面向旧 API consumer 和扩展实现，不是对普遍游戏崩溃或常规相机故障的修复。

## 可能出现的问题

合并 26.1 实现时，`BindResult(BindTarget, boolean)` 和无参数 `computeCamera()` 被替换为 26.1 风格的单参数构造器与 `computeCamera(boolean mirrored)`。仓库内部调用已随之更新，因此正常构建和内置功能不会直接暴露问题；但按旧 1.20.1 API 编译的第三方代码在执行相关路径时，可能遇到 `NoSuchMethodError`。

旧 provider 还可以通过构造器携带 `mirrored=true`。同步后的核心流程固定调用 `computeCamera(false)`，因此外部 provider 的镜像状态可能丢失，表现为相机左右偏移、旋转方向或模型绑定位置错误。非镜像结果不受这一点影响。

此外，`BindResult` 迁移到 `CameraTransform` 后：

- 旧 API 中的 `protected final mirrored` 字段一度不再保留；
- 原本可覆写的 `getPosition()`、`setPosition()` 和 `getRotation()` 变成了 `final`。

依赖这些契约的旧 `BindResult` 子类可能无法重新编译，已有字节码也可能在类加载或执行相应路径时失败。是否实际发生取决于第三方模组是否继承并使用了这些 API。

## 本 PR 的改动

- 恢复 `BindResult(BindTarget, boolean)`，同时保留 26.1 风格的 `BindResult(BindTarget)`。
- 恢复无参数 `computeCamera()`，同时保留显式的 `computeCamera(boolean mirrored)`。
- 让核心流程调用无参数版本，从而继续使用旧 provider 携带的镜像状态。
- 将 `mirrored` 恢复为 `protected final`。
- 恢复 `getPosition()`、`setPosition()` 和 `getRotation()` 的可覆写性。
- 在 `MixinCamera` 中一次取得 yaw/pitch 所需的欧拉角，避免每帧对同一旋转矩阵重复分解。此项主要是小型性能和实现一致性改进，通常不会造成可感知的功能差异。

## 兼容策略

本 PR 不回退新的配置模型或 `CameraTransform` 结构。它以 26.1 实现为主，仅在正式的 `com.xtracr.realcamera.api` 边界保留 1.20.1 旧契约，作为薄兼容层：

- 旧 provider 可以继续使用旧构造器和无参数计算方法；
- 新代码仍可使用 26.1 风格构造器和显式镜像参数；
- 普通非镜像路径的行为保持不变；
- 不包含与该兼容问题无关的重构。

## 验证

- [x] 使用 Java 17 执行 `./gradlew build --no-daemon --rerun-tasks`
- [x] Fabric 与 Forge 构建、access widener 校验及 Mixin 编译
- [x] `javap` 确认两种 `BindResult` 构造器和两种 `computeCamera` 重载均存在
- [x] `javap` 确认 `mirrored` 为 `protected final`，旧位置/旋转访问器保持可覆写
- [x] Mixin 字节码只包含一次 `getEulerAngle` 调用，不再分别调用 `getYaw`/`getPitch`
- [x] 游戏内烟雾测试

当前验证可以确认项目构建、基本运行和 API 字节码形状正确，但尚未使用一个按同步前 1.20.1 API 编译的独立第三方模组，对所有旧 consumer 场景进行端到端测试。相关兼容结论主要来自旧 API 契约、生成字节码和调用路径分析。
