### PR TITLE
[codex] Restore live disable draft preview

### DIFF
--- a/common/src/main/java/com/xtracr/realcamera/gui/ModelViewScreen.java
+++ b/common/src/main/java/com/xtracr/realcamera/gui/ModelViewScreen.java
@@ -683,7 +683,7 @@ public final class ModelViewScreen extends Screen {
         return genBindTarget(previewDisableConfigs(disableConfigs, createDisableDraft()));
     }
 
-    static List<DisableConfig> previewDisableConfigs(List<DisableConfig> disableConfigs, DisableConfig draft) {
+    private static List<DisableConfig> previewDisableConfigs(List<DisableConfig> disableConfigs, DisableConfig draft) {
         List<DisableConfig> previewConfigs = new ArrayList<>(disableConfigs);
         for (int i = 0; i < previewConfigs.size(); i++) {
             if (previewConfigs.get(i).name().equals(draft.name())) {

--- a/common/src/main/java/com/xtracr/realcamera/gui/ModelViewScreen.java
+++ b/common/src/main/java/com/xtracr/realcamera/gui/ModelViewScreen.java
@@ -391,7 +391,7 @@ public final class ModelViewScreen extends Screen {
         graphics.fill(x + (xSize + middleWidth) / 2 + 4, y, x + xSize, y + ySize, SIDE_PANEL_BG);
 
         ModelAnalyser analyser = new ModelAnalyser();
-        BindTarget target = genBindTarget();
+        BindTarget target = toggleCategoryButton.getValue() == Category.DISABLE ? genPreviewBindTarget() : genBindTarget();
         target.offsets().scale *= modelScale;
         String textureId = toggleCategoryButton.getValue() == Category.DISABLE ? disabledIdField.getValue() : "";
         Set<String> hiddenNames = hiddenNameMap.getOrDefault(nameField.getValue(), Set.of());
@@ -573,9 +573,13 @@ public final class ModelViewScreen extends Screen {
             button.setTooltip(Tooltip.create(LocUtil.MODEL_VIEW_TOOLTIP("emptyTextureId").withStyle(ChatFormatting.RED)));
             return false;
         }
-        DisableConfig disableConfig = new DisableConfig(name, textureId, disableModeButton.getValue() == 0, rectWidgets.stream().map(UVRectangleWidget::toUVRectangle).toList());
-        upsertDisableConfig(disableConfig);
+        upsertDisableConfig(createDisableDraft());
         return true;
+    }
+
+    private DisableConfig createDisableDraft() {
+        return new DisableConfig(disabledNameField.getValue(), disabledIdField.getValue(), disableModeButton.getValue() == 0,
+                rectWidgets.stream().map(UVRectangleWidget::toUVRectangle).toList());
     }
 
     private boolean hasMeaningfulDisableDraft() {
@@ -672,10 +676,29 @@ public final class ModelViewScreen extends Screen {
     }
 
     private BindTarget genBindTarget() {
+        return genBindTarget(new ArrayList<>(disableConfigs));
+    }
+
+    private BindTarget genPreviewBindTarget() {
+        return genBindTarget(previewDisableConfigs(disableConfigs, createDisableDraft()));
+    }
+
+    static List<DisableConfig> previewDisableConfigs(List<DisableConfig> disableConfigs, DisableConfig draft) {
+        List<DisableConfig> previewConfigs = new ArrayList<>(disableConfigs);
+        for (int i = 0; i < previewConfigs.size(); i++) {
+            if (previewConfigs.get(i).name().equals(draft.name())) {
+                previewConfigs.set(i, draft);
+                break;
+            }
+        }
+        return previewConfigs;
+    }
+
+    private BindTarget genBindTarget(List<DisableConfig> disableConfigs) {
         TargetConfig targetConfig = new TargetConfig(forwardUField.getNumber(), forwardVField.getNumber(), upwardUField.getNumber(), upwardVField.getNumber(), posUField.getNumber(), posVField.getNumber());
         BindConfig bindConfig = new BindConfig(bindXButton.getValue() == 0, bindYButton.getValue() == 0, bindZButton.getValue() == 0, bindRotButton.getValue() == 0);
         OffsetConfig offsets = new OffsetConfig(scaleField.getNumber(), offsetXPair.getNumber(), offsetYPair.getNumber(), offsetZPair.getNumber(), offsetPitchPair.getNumber(), offsetYawPair.getNumber(), offsetRollPair.getNumber());
-        return new BindTarget(nameField.getValue(), textureIdField.getValue(), priorityField.getNumber(), depthField.getNumber(), targetConfig, bindConfig, offsets, new ArrayList<>(disableConfigs));
+        return new BindTarget(nameField.getValue(), textureIdField.getValue(), priorityField.getNumber(), depthField.getNumber(), targetConfig, bindConfig, offsets, disableConfigs);
     }
 
     private UVRectangleWidget addRectWidget(UVRectangleWidget rectWidget) {

--- a/common/src/main/java/com/xtracr/realcamera/gui/ModelViewScreen.java
+++ b/common/src/main/java/com/xtracr/realcamera/gui/ModelViewScreen.java
@@ -680,18 +680,15 @@ public final class ModelViewScreen extends Screen {
     }
 
     private BindTarget genPreviewBindTarget() {
-        return genBindTarget(previewDisableConfigs(disableConfigs, createDisableDraft()));
-    }
-
-    private static List<DisableConfig> previewDisableConfigs(List<DisableConfig> disableConfigs, DisableConfig draft) {
         List<DisableConfig> previewConfigs = new ArrayList<>(disableConfigs);
+        DisableConfig draft = createDisableDraft();
         for (int i = 0; i < previewConfigs.size(); i++) {
             if (previewConfigs.get(i).name().equals(draft.name())) {
                 previewConfigs.set(i, draft);
                 break;
             }
         }
-        return previewConfigs;
+        return genBindTarget(previewConfigs);
     }
 
     private BindTarget genBindTarget(List<DisableConfig> disableConfigs) {

--- a/common/src/main/java/com/xtracr/realcamera/gui/ModelViewScreen.java
+++ b/common/src/main/java/com/xtracr/realcamera/gui/ModelViewScreen.java
@@ -268,6 +268,7 @@ public final class ModelViewScreen extends Screen {
             BindTarget bindTarget = genBindTarget();
             ConfigFile.config().putBindTarget(bindTarget);
             ConfigFile.save();
+            if (toggleCategoryButton.getValue() != Category.DISABLE) loadBindTarget(bindTarget);
             initWidgets(page);
         }));
         rows.addChild(priorityField, smallSettings).setTooltip(createTooltip("priority"));
@@ -391,7 +392,7 @@ public final class ModelViewScreen extends Screen {
         graphics.fill(x + (xSize + middleWidth) / 2 + 4, y, x + xSize, y + ySize, SIDE_PANEL_BG);
 
         ModelAnalyser analyser = new ModelAnalyser();
-        BindTarget target = toggleCategoryButton.getValue() == Category.DISABLE ? genPreviewBindTarget() : genBindTarget();
+        BindTarget target = genBindTarget();
         target.offsets().scale *= modelScale;
         String textureId = toggleCategoryButton.getValue() == Category.DISABLE ? disabledIdField.getValue() : "";
         Set<String> hiddenNames = hiddenNameMap.getOrDefault(nameField.getValue(), Set.of());
@@ -676,26 +677,18 @@ public final class ModelViewScreen extends Screen {
     }
 
     private BindTarget genBindTarget() {
-        return genBindTarget(new ArrayList<>(disableConfigs));
-    }
-
-    private BindTarget genPreviewBindTarget() {
-        List<DisableConfig> previewConfigs = new ArrayList<>(disableConfigs);
+        List<DisableConfig> newDisableConfigs = new ArrayList<>(disableConfigs);
         DisableConfig draft = createDisableDraft();
-        for (int i = 0; i < previewConfigs.size(); i++) {
-            if (previewConfigs.get(i).name().equals(draft.name())) {
-                previewConfigs.set(i, draft);
+        for (int i = 0; i < newDisableConfigs.size(); i++) {
+            if (newDisableConfigs.get(i).name().equals(draft.name())) {
+                newDisableConfigs.set(i, draft);
                 break;
             }
         }
-        return genBindTarget(previewConfigs);
-    }
-
-    private BindTarget genBindTarget(List<DisableConfig> disableConfigs) {
         TargetConfig targetConfig = new TargetConfig(forwardUField.getNumber(), forwardVField.getNumber(), upwardUField.getNumber(), upwardVField.getNumber(), posUField.getNumber(), posVField.getNumber());
         BindConfig bindConfig = new BindConfig(bindXButton.getValue() == 0, bindYButton.getValue() == 0, bindZButton.getValue() == 0, bindRotButton.getValue() == 0);
         OffsetConfig offsets = new OffsetConfig(scaleField.getNumber(), offsetXPair.getNumber(), offsetYPair.getNumber(), offsetZPair.getNumber(), offsetPitchPair.getNumber(), offsetYawPair.getNumber(), offsetRollPair.getNumber());
-        return new BindTarget(nameField.getValue(), textureIdField.getValue(), priorityField.getNumber(), depthField.getNumber(), targetConfig, bindConfig, offsets, disableConfigs);
+        return new BindTarget(nameField.getValue(), textureIdField.getValue(), priorityField.getNumber(), depthField.getNumber(), targetConfig, bindConfig, offsets, newDisableConfigs);
     }
 
     private UVRectangleWidget addRectWidget(UVRectangleWidget rectWidget) {

--- a/common/src/main/java/com/xtracr/realcamera/gui/ModelViewScreen.java
+++ b/common/src/main/java/com/xtracr/realcamera/gui/ModelViewScreen.java
@@ -574,13 +574,9 @@ public final class ModelViewScreen extends Screen {
             button.setTooltip(Tooltip.create(LocUtil.MODEL_VIEW_TOOLTIP("emptyTextureId").withStyle(ChatFormatting.RED)));
             return false;
         }
-        upsertDisableConfig(createDisableDraft());
+        DisableConfig disableConfig = new DisableConfig(name, textureId, disableModeButton.getValue() == 0, rectWidgets.stream().map(UVRectangleWidget::toUVRectangle).toList());
+        upsertDisableConfig(disableConfig);
         return true;
-    }
-
-    private DisableConfig createDisableDraft() {
-        return new DisableConfig(disabledNameField.getValue(), disabledIdField.getValue(), disableModeButton.getValue() == 0,
-                rectWidgets.stream().map(UVRectangleWidget::toUVRectangle).toList());
     }
 
     private boolean hasMeaningfulDisableDraft() {
@@ -677,13 +673,11 @@ public final class ModelViewScreen extends Screen {
     }
 
     private BindTarget genBindTarget() {
+        DisableConfig currentDisableConfig = new DisableConfig(disabledNameField.getValue(), disabledIdField.getValue(), disableModeButton.getValue() == 0, rectWidgets.stream().map(UVRectangleWidget::toUVRectangle).toList());
         List<DisableConfig> newDisableConfigs = new ArrayList<>(disableConfigs);
-        DisableConfig draft = createDisableDraft();
         for (int i = 0; i < newDisableConfigs.size(); i++) {
-            if (newDisableConfigs.get(i).name().equals(draft.name())) {
-                newDisableConfigs.set(i, draft);
-                break;
-            }
+            if (newDisableConfigs.get(i).name().equals(currentDisableConfig.name()))
+                newDisableConfigs.set(i, currentDisableConfig);
         }
         TargetConfig targetConfig = new TargetConfig(forwardUField.getNumber(), forwardVField.getNumber(), upwardUField.getNumber(), upwardVField.getNumber(), posUField.getNumber(), posVField.getNumber());
         BindConfig bindConfig = new BindConfig(bindXButton.getValue() == 0, bindYButton.getValue() == 0, bindZButton.getValue() == 0, bindRotButton.getValue() == 0);


### PR DESCRIPTION
## Summary

- Restore live preview updates while editing an existing hidden disable setting by overlaying the current same-name draft when generating a `BindTarget`.
- Keep new or renamed disable drafts explicit: drafts without an existing name match are not added until the right-side `+` action or DISABLE-page save synchronizes them.
- Include the current same-name draft in generated targets used by rendering, save, and export.
- Reload the generated target after saving from CONFIGS or PREVIEW so the editor's disable-config list stays synchronized; DISABLE-page saves keep the active draft intact.

## Root cause

PR #213 removed the same-name draft replacement from `genBindTarget()`. That simplified save generation, but also removed the per-frame draft overlay that made edits to an existing hidden disable setting immediately visible.

This PR restores that replacement on a copied disable-config list. The staged source list is not mutated during rendering, and unmatched drafts are not implicitly added.

## Validation

- Temporary JUnit regression tests passed before being removed as requested: same-name replacement, source-list isolation, and unmatched drafts not being added.
- `.\gradlew.bat :common:test`
- `.\gradlew.bat build`
- `git diff --check`
- GitHub Actions `build`