### PR TITLE
[codex] Restore live disable draft preview on 1.21.1

### DIFF
--- a/common/src/main/java/com/xtracr/realcamera/gui/ModelViewScreen.java
+++ b/common/src/main/java/com/xtracr/realcamera/gui/ModelViewScreen.java
@@ -391,7 +391,7 @@ public final class ModelViewScreen extends Screen {
         graphics.fill(x + (xSize + middleWidth) / 2 + 4, y, x + xSize, y + ySize, SIDE_PANEL_BG);
 
         ModelAnalyser analyser = new ModelAnalyser();
-        BindTarget target = genBindTarget();
+        BindTarget target = toggleCategoryButton.getValue() == Category.DISABLE ? genPreviewBindTarget() : genBindTarget();
         target.offsets().scale *= modelScale;
         String textureId = toggleCategoryButton.getValue() == Category.DISABLE ? disabledIdField.getValue() : "";
         Set<String> hiddenNames = hiddenNameMap.getOrDefault(nameField.getValue(), Set.of());
@@ -566,9 +566,13 @@ public final class ModelViewScreen extends Screen {
             button.setTooltip(Tooltip.create(LocUtil.MODEL_VIEW_TOOLTIP("emptyTextureId").withStyle(ChatFormatting.RED)));
             return false;
         }
-        DisableConfig disableConfig = new DisableConfig(name, textureId, disableModeButton.getValue() == 0, rectWidgets.stream().map(UVRectangleWidget::toUVRectangle).toList());
-        upsertDisableConfig(disableConfig);
+        upsertDisableConfig(createDisableDraft());
         return true;
+    }
+
+    private DisableConfig createDisableDraft() {
+        return new DisableConfig(disabledNameField.getValue(), disabledIdField.getValue(), disableModeButton.getValue() == 0,
+                rectWidgets.stream().map(UVRectangleWidget::toUVRectangle).toList());
     }
 
     private boolean hasMeaningfulDisableDraft() {
@@ -665,10 +669,29 @@ public final class ModelViewScreen extends Screen {
     }
 
     private BindTarget genBindTarget() {
+        return genBindTarget(new ArrayList<>(disableConfigs));
+    }
+
+    private BindTarget genPreviewBindTarget() {
+        return genBindTarget(previewDisableConfigs(disableConfigs, createDisableDraft()));
+    }
+
+    static List<DisableConfig> previewDisableConfigs(List<DisableConfig> disableConfigs, DisableConfig draft) {
+        List<DisableConfig> previewConfigs = new ArrayList<>(disableConfigs);
+        for (int i = 0; i < previewConfigs.size(); i++) {
+            if (previewConfigs.get(i).name().equals(draft.name())) {
+                previewConfigs.set(i, draft);
+                break;
+            }
+        }
+        return previewConfigs;
+    }
+
+    private BindTarget genBindTarget(List<DisableConfig> disableConfigs) {
         TargetConfig targetConfig = new TargetConfig(forwardUField.getNumber(), forwardVField.getNumber(), upwardUField.getNumber(), upwardVField.getNumber(), posUField.getNumber(), posVField.getNumber());
         BindConfig bindConfig = new BindConfig(bindXButton.getValue() == 0, bindYButton.getValue() == 0, bindZButton.getValue() == 0, bindRotButton.getValue() == 0);
         OffsetConfig offsets = new OffsetConfig(scaleField.getNumber(), offsetXPair.getNumber(), offsetYPair.getNumber(), offsetZPair.getNumber(), offsetPitchPair.getNumber(), offsetYawPair.getNumber(), offsetRollPair.getNumber());
-        return new BindTarget(nameField.getValue(), textureIdField.getValue(), priorityField.getNumber(), depthField.getNumber(), targetConfig, bindConfig, offsets, new ArrayList<>(disableConfigs));
+        return new BindTarget(nameField.getValue(), textureIdField.getValue(), priorityField.getNumber(), depthField.getNumber(), targetConfig, bindConfig, offsets, disableConfigs);
     }
 
     private UVRectangleWidget addRectWidget(UVRectangleWidget rectWidget) {

--- a/common/src/main/java/com/xtracr/realcamera/gui/ModelViewScreen.java
+++ b/common/src/main/java/com/xtracr/realcamera/gui/ModelViewScreen.java
@@ -673,18 +673,15 @@ public final class ModelViewScreen extends Screen {
     }
 
     private BindTarget genPreviewBindTarget() {
-        return genBindTarget(previewDisableConfigs(disableConfigs, createDisableDraft()));
-    }
-
-    static List<DisableConfig> previewDisableConfigs(List<DisableConfig> disableConfigs, DisableConfig draft) {
         List<DisableConfig> previewConfigs = new ArrayList<>(disableConfigs);
+        DisableConfig draft = createDisableDraft();
         for (int i = 0; i < previewConfigs.size(); i++) {
             if (previewConfigs.get(i).name().equals(draft.name())) {
                 previewConfigs.set(i, draft);
                 break;
             }
         }
-        return previewConfigs;
+        return genBindTarget(previewConfigs);
     }
 
     private BindTarget genBindTarget(List<DisableConfig> disableConfigs) {


### PR DESCRIPTION
## Summary

- Backport the live disable draft preview fix from #223 to 1.21.1.
- Overlay the current draft only while rendering the DISABLE page.
- Keep save, export, and unmatched new-draft behavior unchanged.

## Root cause

The model preview used only the staged `disableConfigs`, so edits in the current rectangle draft were not visible until the draft was synchronized by Save or the right-side add/update button.

## Validation

- Three temporary JUnit regression tests passed before being removed as requested: same-name overlay, source-list isolation, and unmatched drafts not being added.
- `.\gradlew.bat :common:test`
- `.\gradlew.bat build`
- `git diff --check`
