### PR TITLE
[codex] Restore live disable draft preview on 1.20.1

### DIFF
--- a/common/src/main/java/com/xtracr/realcamera/gui/ModelViewScreen.java
+++ b/common/src/main/java/com/xtracr/realcamera/gui/ModelViewScreen.java
@@ -660,18 +660,15 @@ public class ModelViewScreen extends Screen {
     }
 
     private BindTarget genPreviewBindTarget() {
-        return genBindTarget(previewDisableConfigs(disableConfigs, createDisableDraft()));
-    }
-
-    static List<DisableConfig> previewDisableConfigs(List<DisableConfig> disableConfigs, DisableConfig draft) {
         List<DisableConfig> previewConfigs = new ArrayList<>(disableConfigs);
+        DisableConfig draft = createDisableDraft();
         for (int i = 0; i < previewConfigs.size(); i++) {
             if (previewConfigs.get(i).name().equals(draft.name())) {
                 previewConfigs.set(i, draft);
                 break;
             }
         }
-        return previewConfigs;
+        return genBindTarget(previewConfigs);
     }
 
     private BindTarget genBindTarget(List<DisableConfig> disableConfigs) {

--- a/common/src/main/java/com/xtracr/realcamera/gui/ModelViewScreen.java
+++ b/common/src/main/java/com/xtracr/realcamera/gui/ModelViewScreen.java
@@ -415,9 +415,13 @@ public class ModelViewScreen extends Screen {
             button.setTooltip(Tooltip.create(LocUtil.MODEL_VIEW_TOOLTIP("emptyTextureId").withStyle(ChatFormatting.RED)));
             return false;
         }
-        DisableConfig disableConfig = new DisableConfig(name, textureId, disableModeButton.getValue() == 0, rectWidgets.stream().map(UVRectangleWidget::toUVRectangle).toList());
-        upsertDisableConfig(disableConfig);
+        upsertDisableConfig(createDisableDraft());
         return true;
+    }
+
+    private DisableConfig createDisableDraft() {
+        return new DisableConfig(disabledNameField.getValue().trim(), disabledIdField.getValue().trim(), disableModeButton.getValue() == 0,
+                rectWidgets.stream().map(UVRectangleWidget::toUVRectangle).toList());
     }
 
     private boolean hasMeaningfulDisableDraft() {
@@ -500,7 +504,7 @@ public class ModelViewScreen extends Screen {
     @Override
     public void render(GuiGraphics graphics, int mouseX, int mouseY, float deltaTick) {
         renderBackground(graphics);
-        analyser.initialize(genBindTarget(), modelScale);
+        analyser.initialize(toggleCategoryButton.getValue() == Category.DISABLE ? genPreviewBindTarget() : genBindTarget(), modelScale);
         renderModelViewArea(graphics, minecraft.player);
         renderTextureViewArea(graphics);
         applyAnalyser(graphics, mouseX, mouseY);
@@ -652,6 +656,25 @@ public class ModelViewScreen extends Screen {
     }
 
     protected BindTarget genBindTarget() {
+        return genBindTarget(new ArrayList<>(disableConfigs));
+    }
+
+    private BindTarget genPreviewBindTarget() {
+        return genBindTarget(previewDisableConfigs(disableConfigs, createDisableDraft()));
+    }
+
+    static List<DisableConfig> previewDisableConfigs(List<DisableConfig> disableConfigs, DisableConfig draft) {
+        List<DisableConfig> previewConfigs = new ArrayList<>(disableConfigs);
+        for (int i = 0; i < previewConfigs.size(); i++) {
+            if (previewConfigs.get(i).name().equals(draft.name())) {
+                previewConfigs.set(i, draft);
+                break;
+            }
+        }
+        return previewConfigs;
+    }
+
+    private BindTarget genBindTarget(List<DisableConfig> disableConfigs) {
         initOffsetPairs();
         TargetConfig targetConfig = new TargetConfig( forwardUField.getNumber(), forwardVField.getNumber(), upwardUField.getNumber(), upwardVField.getNumber(), posUField.getNumber(), posVField.getNumber());
         BindConfig bindConfig = new BindConfig( bindXButton.getValue() == 0, bindYButton.getValue() == 0, bindZButton.getValue() == 0, bindRotButton.getValue() == 0);
@@ -663,7 +686,7 @@ public class ModelViewScreen extends Screen {
                 .setPitch(offsetPitchPair.getNumber())
                 .setYaw(offsetYawPair.getNumber())
                 .setRoll(offsetRollPair.getNumber());
-        return new BindTarget(nameField.getValue(), textureIdField.getValue(), priorityField.getNumber(), depthField.getNumber(), targetConfig, bindConfig, offsets, new ArrayList<>(disableConfigs));
+        return new BindTarget(nameField.getValue(), textureIdField.getValue(), priorityField.getNumber(), depthField.getNumber(), targetConfig, bindConfig, offsets, disableConfigs);
     }
 
     private void clearDisableDraft() {


### PR DESCRIPTION
## Summary

- Backport the live disable draft preview fix from #223 to 1.20.1.
- Feed the preview-only target into the legacy `ModelAnalyser` initialization path.
- Preserve trimmed disable names/texture IDs and existing save/export behavior.

## Root cause

The model preview used only the staged `disableConfigs`, so edits in the current rectangle draft were not visible until the draft was synchronized by Save or the right-side add/update button.

## Validation

- Three temporary JUnit regression tests passed before being removed as requested: same-name overlay, source-list isolation, and unmatched drafts not being added.
- `.\gradlew.bat --no-daemon "-Dorg.gradle.java.home=C:\Program Files\Eclipse Adoptium\jdk-17.0.16.8-hotspot" :common:test`
- `.\gradlew.bat --no-daemon "-Dorg.gradle.java.home=C:\Program Files\Eclipse Adoptium\jdk-17.0.16.8-hotspot" build`
- `git diff --check`
