### PR TITLE
Show Dragon Survival head and neck in first person

### DIFF
--- a/common/src/main/java/com/xtracr/realcamera/mixin/MixinDragonSurvivalCompat.java
+++ b/common/src/main/java/com/xtracr/realcamera/mixin/MixinDragonSurvivalCompat.java
@@ -1,0 +1,17 @@
+package com.xtracr.realcamera.mixin;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.xtracr.realcamera.RealCameraCore;
+import com.xtracr.realcamera.compat.CompatibilityHelper;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Pseudo
+@Mixin(targets = "by.dragonsurvivalteam.dragonsurvival.compat.Compat", remap = false)
+public abstract class MixinDragonSurvivalCompat {
+    @ModifyReturnValue(method = "displayNeck()Z", at = @At("RETURN"), remap = false, require = 0, expect = 1)
+    private static boolean realcamera$displayDragonNeck(boolean original) {
+        return original || RealCameraCore.isActive() || CompatibilityHelper.isRenderInScreen;
+    }
+}

--- a/common/src/main/resources/realcamera-common.mixins.json
+++ b/common/src/main/resources/realcamera-common.mixins.json
@@ -7,6 +7,7 @@
   ],
   "client": [
     "MixinCamera",
+    "MixinDragonSurvivalCompat",
     "MixinFishingHookRenderer",
     "MixinGameRenderer",
     "MixinGui",


### PR DESCRIPTION
## Summary

This PR adds minimal compatibility for Dragon Survival by keeping the dragon head and neck visible while RealCamera is active.

The fix applies to:

* Binding mode
* Classic mode
* RealCamera's model view screen

## Root cause

Dragon Survival intentionally hides the dragon head and neck in normal first-person rendering through its `Compat.displayNeck()` method.

Because the geometry is not submitted by Dragon Survival, RealCamera cannot capture or render the missing head model by itself.

The latest Dragon Survival 26.1 code otherwise works correctly with RealCamera, so no model ownership changes, GeckoLib-specific rendering hooks, or texture filtering are required.

## Implementation

This PR adds an optional `@Pseudo` mixin targeting:

```java
by.dragonsurvivalteam.dragonsurvival.compat.Compat
```

It modifies the return value of `displayNeck()` so that the original result is preserved, while also displaying the head and neck when:

* RealCamera is active in first person
* RealCamera is capturing the model for its model view screen

```java
return original
        || RealCameraCore.isActive()
        || CompatibilityHelper.isRenderInScreen;
```

The mixin uses `require = 0`, so RealCamera can still load normally when Dragon Survival is not installed or when the target method is unavailable.

## Scope

This change intentionally does not add:

* A Dragon Survival compile-time dependency
* Dragon state reflection
* First-person body ownership arbitration
* GeckoLib-specific geometry filtering
* Dragon-specific disable configuration handling
* Texture-layer or armor-layer handling

These systems are unnecessary for the current Dragon Survival 26.1 implementation.

## Validation

The following cases should be checked:

* Binding mode displays the dragon head and neck
* Classic mode displays the dragon head and neck
* The model view screen captures the complete dragon model
* Disabling RealCamera restores Dragon Survival's original first-person behavior
* RealCamera starts normally without Dragon Survival installed
